### PR TITLE
add pages: contests & statistics

### DIFF
--- a/archetypes/kotohazi.md
+++ b/archetypes/kotohazi.md
@@ -8,6 +8,12 @@ problems:
 - {{$id}}
 ---
 
+{{% hasProbdata id={{$id}} key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id={{$id}} %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id={{$id}} detailed=true %}}{{% hasProbdata id={{$id}} key="probcorrection" %}}

--- a/archetypes/nonlo.md
+++ b/archetypes/nonlo.md
@@ -9,6 +9,12 @@ problems:
 - {{$id}}
 ---
 
+{{% hasProbdata id={{$id}} key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id={{$id}} %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id={{$id}} detailed=true %}}{{% hasProbdata id={{$id}} key="probcorrection" %}}

--- a/archetypes/oversea.md
+++ b/archetypes/oversea.md
@@ -8,6 +8,12 @@ problems:
 - {{$id}}
 ---
 
+{{% hasProbdata id={{$id}} key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id={{$id}} %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id={{$id}} detailed=true %}}{{% hasProbdata id={{$id}} key="probcorrection" %}}

--- a/archetypes/problems.md
+++ b/archetypes/problems.md
@@ -8,6 +8,12 @@ problems:
 - {{$id}}
 ---
 
+{{% hasProbdata id={{$id}} key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id={{$id}} %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id={{$id}} detailed=true %}}{{% hasProbdata id={{$id}} key="probcorrection" %}}

--- a/assets/js/database-charts.js
+++ b/assets/js/database-charts.js
@@ -1,0 +1,5 @@
+// Load the Visualization API and the corechart package.
+google.charts.load('current', {'packages':['corechart']});
+
+// Set a callback to run when the Google Visualization API is loaded.
+google.charts.setOnLoadCallback(drawCharts);

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -88,6 +88,17 @@ figcaption{
     }
 }
 
+.transition-none{
+    transition: none;
+    &.collapsing{
+        transition: none;
+    }
+}
+
+.ml-1_25{
+    margin-left: 1.25rem;
+}
+
 a {
     word-break: break-all;
 }

--- a/content/ja/problems/APLO/2019/1.md
+++ b/content/ja/problems/APLO/2019/1.md
@@ -1,12 +1,18 @@
 ---
 title: "APLO2019-1 イク語"
-weight: 1
+weight: 105
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 105
 ---
+
+{{% hasProbdata id=105 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=105 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/APLO/2019/2.md
+++ b/content/ja/problems/APLO/2019/2.md
@@ -1,12 +1,18 @@
 ---
 title: "APLO2019-2 ウラリナ語"
-weight: 2
+weight: 106
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 106
 ---
+
+{{% hasProbdata id=106 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=106 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/APLO/2019/3.md
+++ b/content/ja/problems/APLO/2019/3.md
@@ -1,12 +1,18 @@
 ---
 title: "APLO2019-3 メエ語"
-weight: 3
+weight: 107
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 107
 ---
+
+{{% hasProbdata id=107 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=107 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/APLO/2019/4.md
+++ b/content/ja/problems/APLO/2019/4.md
@@ -1,12 +1,18 @@
 ---
 title: "APLO2019-4 ヘブライ語"
-weight: 4
+weight: 108
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 108
 ---
+
+{{% hasProbdata id=108 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=108 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/APLO/2019/5.md
+++ b/content/ja/problems/APLO/2019/5.md
@@ -1,12 +1,18 @@
 ---
 title: "APLO2019-5 古チュルク文字"
-weight: 5
+weight: 109
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 109
 ---
+
+{{% hasProbdata id=109 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=109 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2003/1.md
+++ b/content/ja/problems/IOL/2003/1.md
@@ -8,6 +8,12 @@ problems:
 - 1
 ---
 
+{{% hasProbdata id=1 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=1 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=1 detailed=true %}}{{% hasProbdata id=1 key="probcorrection" %}}

--- a/content/ja/problems/IOL/2003/2.md
+++ b/content/ja/problems/IOL/2003/2.md
@@ -8,6 +8,12 @@ problems:
 - 2
 ---
 
+{{% hasProbdata id=2 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=2 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=2 detailed=true %}}{{% hasProbdata id=2 key="probcorrection" %}}

--- a/content/ja/problems/IOL/2003/3.md
+++ b/content/ja/problems/IOL/2003/3.md
@@ -8,6 +8,12 @@ problems:
 - 3
 ---
 
+{{% hasProbdata id=3 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=3 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=3 detailed=true %}}{{% hasProbdata id=3 key="probcorrection" %}}

--- a/content/ja/problems/IOL/2003/4.md
+++ b/content/ja/problems/IOL/2003/4.md
@@ -8,6 +8,12 @@ problems:
 - 4
 ---
 
+{{% hasProbdata id=4 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=4 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=4 detailed=true %}}{{% hasProbdata id=4 key="probcorrection" %}}

--- a/content/ja/problems/IOL/2003/5.md
+++ b/content/ja/problems/IOL/2003/5.md
@@ -8,6 +8,12 @@ problems:
 - 5
 ---
 
+{{% hasProbdata id=5 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=5 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=5 detailed=true %}}{{% hasProbdata id=5 key="probcorrection" %}}

--- a/content/ja/problems/IOL/2003/team-1.md
+++ b/content/ja/problems/IOL/2003/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2003-team-1 トカラ語"
-weight: 991
+weight: 6
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 6
 ---
+
+{{% hasProbdata id=6 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=6 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2003/team-2.md
+++ b/content/ja/problems/IOL/2003/team-2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2003-team-2 添え字"
-weight: 992
+weight: 7
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 7
 ---
+
+{{% hasProbdata id=7 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=7 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2003/team-3.md
+++ b/content/ja/problems/IOL/2003/team-3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2003-team-3 動詞"
-weight: 993
+weight: 8
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 8
 ---
+
+{{% hasProbdata id=8 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=8 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2004/1.md
+++ b/content/ja/problems/IOL/2004/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2004-1 カヤポ語"
-weight: 1
+weight: 9
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 9
 ---
+
+{{% hasProbdata id=9 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=9 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2004/2.md
+++ b/content/ja/problems/IOL/2004/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2004-2 韋駄天通信社"
-weight: 2
+weight: 10
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 10
 ---
+
+{{% hasProbdata id=10 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=10 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2004/3.md
+++ b/content/ja/problems/IOL/2004/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2004-3 ラテン語"
-weight: 3
+weight: 11
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 11
 ---
+
+{{% hasProbdata id=11 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=11 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2004/4.md
+++ b/content/ja/problems/IOL/2004/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2004-4 ラコタ語"
-weight: 4
+weight: 12
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 12
 ---
+
+{{% hasProbdata id=12 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=12 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2004/5.md
+++ b/content/ja/problems/IOL/2004/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2004-5 チュヴァシュ語"
-weight: 5
+weight: 13
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 13
 ---
+
+{{% hasProbdata id=13 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=13 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2004/team-1.md
+++ b/content/ja/problems/IOL/2004/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2004-team-1 アルメニア語"
-weight: 991
+weight: 14
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 14
 ---
+
+{{% hasProbdata id=14 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=14 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2005/1.md
+++ b/content/ja/problems/IOL/2005/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2005-1 ツォツィル語"
-weight: 1
+weight: 15
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 15
 ---
+
+{{% hasProbdata id=15 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=15 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2005/2.md
+++ b/content/ja/problems/IOL/2005/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2005-2 ランゴ語"
-weight: 2
+weight: 16
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 16
 ---
+
+{{% hasProbdata id=16 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=16 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2005/3.md
+++ b/content/ja/problems/IOL/2005/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2005-3 マンシ語"
-weight: 3
+weight: 17
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 17
 ---
+
+{{% hasProbdata id=17 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=17 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2005/4.md
+++ b/content/ja/problems/IOL/2005/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2005-4 ヨルバ語"
-weight: 4
+weight: 18
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 18
 ---
+
+{{% hasProbdata id=18 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=18 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2005/5.md
+++ b/content/ja/problems/IOL/2005/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2005-5 リトアニア語"
-weight: 5
+weight: 19
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 19
 ---
+
+{{% hasProbdata id=19 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=19 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2005/team-1.md
+++ b/content/ja/problems/IOL/2005/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2005-team-1 フィギグ語"
-weight: 991
+weight: 20
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 20
 ---
+
+{{% hasProbdata id=20 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=20 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2006/1.md
+++ b/content/ja/problems/IOL/2006/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2006-1 ラコタ語"
-weight: 1
+weight: 21
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 21
 ---
+
+{{% hasProbdata id=21 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=21 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2006/2.md
+++ b/content/ja/problems/IOL/2006/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2006-2 カタラン語"
-weight: 2
+weight: 22
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 22
 ---
+
+{{% hasProbdata id=22 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=22 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2006/3.md
+++ b/content/ja/problems/IOL/2006/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2006-3 クメール語"
-weight: 3
+weight: 23
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 23
 ---
+
+{{% hasProbdata id=23 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=23 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2006/4.md
+++ b/content/ja/problems/IOL/2006/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2006-4 ウディヘ語"
-weight: 4
+weight: 24
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 24
 ---
+
+{{% hasProbdata id=24 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=24 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2006/5.md
+++ b/content/ja/problems/IOL/2006/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2006-5 ンゴニ語"
-weight: 5
+weight: 25
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 25
 ---
+
+{{% hasProbdata id=25 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=25 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2006/team-1.md
+++ b/content/ja/problems/IOL/2006/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2006-team-1 アメリカ手話"
-weight: 991
+weight: 26
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 26
 ---
+
+{{% hasProbdata id=26 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=26 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2007/1.md
+++ b/content/ja/problems/IOL/2007/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2007-1 点字"
-weight: 1
+weight: 27
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 27
 ---
+
+{{% hasProbdata id=27 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=27 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2007/2.md
+++ b/content/ja/problems/IOL/2007/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2007-2 モビマ語"
-weight: 2
+weight: 28
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 28
 ---
+
+{{% hasProbdata id=28 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=28 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2007/3.md
+++ b/content/ja/problems/IOL/2007/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2007-3 グルジア語"
-weight: 3
+weight: 29
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 29
 ---
+
+{{% hasProbdata id=29 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=29 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2007/4.md
+++ b/content/ja/problems/IOL/2007/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2007-4 ンドム語"
-weight: 4
+weight: 30
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 30
 ---
+
+{{% hasProbdata id=30 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=30 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2007/5.md
+++ b/content/ja/problems/IOL/2007/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2007-5 トルコ語とタタール語"
-weight: 5
+weight: 31
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 31
 ---
+
+{{% hasProbdata id=31 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=31 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2007/team-1.md
+++ b/content/ja/problems/IOL/2007/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2007-team-1 ハワイ語"
-weight: 991
+weight: 32
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 32
 ---
+
+{{% hasProbdata id=32 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=32 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2008/1.md
+++ b/content/ja/problems/IOL/2008/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2008-1 ミクマク語"
-weight: 1
+weight: 33
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 33
 ---
+
+{{% hasProbdata id=33 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=33 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2008/2.md
+++ b/content/ja/problems/IOL/2008/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2008-2 古ノルド語"
-weight: 2
+weight: 34
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 34
 ---
+
+{{% hasProbdata id=34 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=34 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2008/3.md
+++ b/content/ja/problems/IOL/2008/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2008-3 デフ語とチェムヒン語"
-weight: 3
+weight: 35
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 35
 ---
+
+{{% hasProbdata id=35 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=35 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2008/4.md
+++ b/content/ja/problems/IOL/2008/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2008-4 コパイナラ・ソケ語"
-weight: 4
+weight: 36
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 36
 ---
+
+{{% hasProbdata id=36 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=36 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2008/5.md
+++ b/content/ja/problems/IOL/2008/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2008-5 イヌクティトゥット語"
-weight: 5
+weight: 37
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 37
 ---
+
+{{% hasProbdata id=37 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=37 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2008/team-1.md
+++ b/content/ja/problems/IOL/2008/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2008-team-1 反切"
-weight: 991
+weight: 38
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 38
 ---
+
+{{% hasProbdata id=38 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=38 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2009/1.md
+++ b/content/ja/problems/IOL/2009/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2009-1 スルカ語"
-weight: 1
+weight: 39
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 39
 ---
+
+{{% hasProbdata id=39 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=39 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2009/2.md
+++ b/content/ja/problems/IOL/2009/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2009-2 マニンカ語とバマナ語"
-weight: 2
+weight: 40
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 40
 ---
+
+{{% hasProbdata id=40 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=40 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2009/3.md
+++ b/content/ja/problems/IOL/2009/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2009-3 ミャンマー人の名"
-weight: 3
+weight: 41
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 41
 ---
+
+{{% hasProbdata id=41 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=41 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2009/4.md
+++ b/content/ja/problems/IOL/2009/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2009-4 古インド語"
-weight: 4
+weight: 42
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 42
 ---
+
+{{% hasProbdata id=42 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=42 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2009/5.md
+++ b/content/ja/problems/IOL/2009/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2009-5 ナワトル語"
-weight: 5
+weight: 43
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 43
 ---
+
+{{% hasProbdata id=43 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=43 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2009/team-1.md
+++ b/content/ja/problems/IOL/2009/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2009-team-1 ベトナム語"
-weight: 991
+weight: 44
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 44
 ---
+
+{{% hasProbdata id=44 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=44 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2010/1.md
+++ b/content/ja/problems/IOL/2010/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2010-1 ブドゥフ語"
-weight: 1
+weight: 45
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 45
 ---
+
+{{% hasProbdata id=45 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=45 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2010/2.md
+++ b/content/ja/problems/IOL/2010/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2010-2 デフ語の数詞"
-weight: 2
+weight: 46
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 46
 ---
+
+{{% hasProbdata id=46 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=46 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2010/3.md
+++ b/content/ja/problems/IOL/2010/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2010-3 ブリスシンボル"
-weight: 3
+weight: 47
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 47
 ---
+
+{{% hasProbdata id=47 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=47 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2010/4.md
+++ b/content/ja/problems/IOL/2010/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2010-4 mRNAシークエンシング"
-weight: 4
+weight: 48
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 48
 ---
+
+{{% hasProbdata id=48 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=48 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2010/5.md
+++ b/content/ja/problems/IOL/2010/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2010-5 ロマンシュ語"
-weight: 5
+weight: 49
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 49
 ---
+
+{{% hasProbdata id=49 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=49 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2010/team-1.md
+++ b/content/ja/problems/IOL/2010/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2010-team-1 モンゴル語"
-weight: 991
+weight: 50
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 50
 ---
+
+{{% hasProbdata id=50 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=50 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2011/1.md
+++ b/content/ja/problems/IOL/2011/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2011-1 メノミニー語"
-weight: 1
+weight: 51
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 51
 ---
+
+{{% hasProbdata id=51 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=51 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2011/2.md
+++ b/content/ja/problems/IOL/2011/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2011-2 フェロー語"
-weight: 2
+weight: 52
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 52
 ---
+
+{{% hasProbdata id=52 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=52 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2011/3.md
+++ b/content/ja/problems/IOL/2011/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2011-3 ヴァイ語"
-weight: 3
+weight: 53
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 53
 ---
+
+{{% hasProbdata id=53 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=53 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2011/4.md
+++ b/content/ja/problems/IOL/2011/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2011-4 ナワトル語"
-weight: 4
+weight: 54
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 54
 ---
+
+{{% hasProbdata id=54 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=54 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2011/5.md
+++ b/content/ja/problems/IOL/2011/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2011-5 EAN-13"
-weight: 5
+weight: 55
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 55
 ---
+
+{{% hasProbdata id=55 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=55 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2011/team-1.md
+++ b/content/ja/problems/IOL/2011/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2011-team-1 サンスクリット詩"
-weight: 991
+weight: 56
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 56
 ---
+
+{{% hasProbdata id=56 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=56 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2012/1.md
+++ b/content/ja/problems/IOL/2012/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2012-1 ジルバル語"
-weight: 1
+weight: 57
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 57
 ---
+
+{{% hasProbdata id=57 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=57 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2012/2.md
+++ b/content/ja/problems/IOL/2012/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2012-2 ウンブ・ウング語"
-weight: 2
+weight: 58
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 58
 ---
+
+{{% hasProbdata id=58 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=58 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2012/3.md
+++ b/content/ja/problems/IOL/2012/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2012-3 バスク語"
-weight: 3
+weight: 59
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 59
 ---
+
+{{% hasProbdata id=59 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=59 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2012/4.md
+++ b/content/ja/problems/IOL/2012/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2012-4 テオプ語"
-weight: 4
+weight: 60
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 60
 ---
+
+{{% hasProbdata id=60 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=60 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2012/5.md
+++ b/content/ja/problems/IOL/2012/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2012-5 ロツマ語"
-weight: 5
+weight: 61
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 61
 ---
+
+{{% hasProbdata id=61 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=61 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2012/team-1.md
+++ b/content/ja/problems/IOL/2012/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2012-team-1 ラオ語"
-weight: 991
+weight: 62
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 62
 ---
+
+{{% hasProbdata id=62 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=62 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2013/1.md
+++ b/content/ja/problems/IOL/2013/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2013-1 イディン語"
-weight: 1
+weight: 63
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 63
 ---
+
+{{% hasProbdata id=63 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=63 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2013/2.md
+++ b/content/ja/problems/IOL/2013/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2013-2 ツンドラ・ユカギール語"
-weight: 2
+weight: 64
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 64
 ---
+
+{{% hasProbdata id=64 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=64 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2013/3.md
+++ b/content/ja/problems/IOL/2013/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2013-3 ピダハン語"
-weight: 3
+weight: 65
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 65
 ---
+
+{{% hasProbdata id=65 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=65 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2013/4.md
+++ b/content/ja/problems/IOL/2013/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2013-4 ムナ語"
-weight: 4
+weight: 66
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 66
 ---
+
+{{% hasProbdata id=66 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=66 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2013/5.md
+++ b/content/ja/problems/IOL/2013/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2013-5 テレパシー"
-weight: 5
+weight: 67
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 67
 ---
+
+{{% hasProbdata id=67 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=67 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2013/team-1.md
+++ b/content/ja/problems/IOL/2013/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2013-team-1 グルジア語"
-weight: 991
+weight: 68
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 68
 ---
+
+{{% hasProbdata id=68 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=68 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2014/1.md
+++ b/content/ja/problems/IOL/2014/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2014-1 ベナベナ語"
-weight: 1
+weight: 69
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 69
 ---
+
+{{% hasProbdata id=69 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=69 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2014/2.md
+++ b/content/ja/problems/IOL/2014/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2014-2 カイオワ語"
-weight: 2
+weight: 70
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 70
 ---
+
+{{% hasProbdata id=70 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=70 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2014/3.md
+++ b/content/ja/problems/IOL/2014/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2014-3 西夏語"
-weight: 3
+weight: 71
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 71
 ---
+
+{{% hasProbdata id=71 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=71 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2014/4.md
+++ b/content/ja/problems/IOL/2014/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2014-4 エンゲンニ語"
-weight: 4
+weight: 72
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 72
 ---
+
+{{% hasProbdata id=72 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=72 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2014/5.md
+++ b/content/ja/problems/IOL/2014/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2014-5 北西バヤ語"
-weight: 5
+weight: 73
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 73
 ---
+
+{{% hasProbdata id=73 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=73 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2014/team-1.md
+++ b/content/ja/problems/IOL/2014/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2014-team-1 アルメニア語"
-weight: 991
+weight: 74
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 74
 ---
+
+{{% hasProbdata id=74 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=74 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2015/1.md
+++ b/content/ja/problems/IOL/2015/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2015-1 ナワトル語とアランバ語"
-weight: 1
+weight: 75
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 75
 ---
+
+{{% hasProbdata id=75 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=75 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2015/2.md
+++ b/content/ja/problems/IOL/2015/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2015-2 カバルド語"
-weight: 2
+weight: 76
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 76
 ---
+
+{{% hasProbdata id=76 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=76 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2015/3.md
+++ b/content/ja/problems/IOL/2015/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2015-3 サウンデックス"
-weight: 3
+weight: 77
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 77
 ---
+
+{{% hasProbdata id=77 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=77 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2015/4.md
+++ b/content/ja/problems/IOL/2015/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2015-4 ワンバヤ語"
-weight: 4
+weight: 78
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 78
 ---
+
+{{% hasProbdata id=78 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=78 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2015/5.md
+++ b/content/ja/problems/IOL/2015/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2015-5 ソマリ語詩マサフォ"
-weight: 5
+weight: 79
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 79
 ---
+
+{{% hasProbdata id=79 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=79 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2015/team-1.md
+++ b/content/ja/problems/IOL/2015/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2015-team-1 北ソト語"
-weight: 991
+weight: 80
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 80
 ---
+
+{{% hasProbdata id=80 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=80 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2016/1.md
+++ b/content/ja/problems/IOL/2016/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2016-1 アラッレ・タブラハン語"
-weight: 1
+weight: 81
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 81
 ---
+
+{{% hasProbdata id=81 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=81 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2016/2.md
+++ b/content/ja/problems/IOL/2016/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2016-2 ルウィ語"
-weight: 2
+weight: 82
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 82
 ---
+
+{{% hasProbdata id=82 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=82 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2016/3.md
+++ b/content/ja/problems/IOL/2016/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2016-3 クヌーズ・ヌビア語"
-weight: 3
+weight: 83
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 83
 ---
+
+{{% hasProbdata id=83 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=83 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2016/4.md
+++ b/content/ja/problems/IOL/2016/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2016-4 イアトムル語"
-weight: 4
+weight: 84
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 84
 ---
+
+{{% hasProbdata id=84 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=84 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2016/5.md
+++ b/content/ja/problems/IOL/2016/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2016-5 ハカル語"
-weight: 5
+weight: 85
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 85
 ---
+
+{{% hasProbdata id=85 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=85 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2016/team-1.md
+++ b/content/ja/problems/IOL/2016/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2016-team-1 タア語"
-weight: 991
+weight: 86
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 86
 ---
+
+{{% hasProbdata id=86 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=86 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2017/1.md
+++ b/content/ja/problems/IOL/2017/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2017-1 ビロム語"
-weight: 1
+weight: 87
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 87
 ---
+
+{{% hasProbdata id=87 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=87 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2017/2.md
+++ b/content/ja/problems/IOL/2017/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2017-2 アブイ語"
-weight: 2
+weight: 88
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 88
 ---
+
+{{% hasProbdata id=88 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=88 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2017/3.md
+++ b/content/ja/problems/IOL/2017/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2017-3 キンブンド語"
-weight: 3
+weight: 89
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 89
 ---
+
+{{% hasProbdata id=89 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=89 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2017/4.md
+++ b/content/ja/problems/IOL/2017/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2017-4 コム文字/ラベン語"
-weight: 4
+weight: 90
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 90
 ---
+
+{{% hasProbdata id=90 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=90 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2017/5.md
+++ b/content/ja/problems/IOL/2017/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2017-5 マダク語"
-weight: 5
+weight: 91
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 91
 ---
+
+{{% hasProbdata id=91 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=91 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2017/team-1.md
+++ b/content/ja/problems/IOL/2017/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2017-team-1 絵文字/インドネシア語"
-weight: 991
+weight: 92
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 92
 ---
+
+{{% hasProbdata id=92 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=92 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2018/1.md
+++ b/content/ja/problems/IOL/2018/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2018-1 クリーク語"
-weight: 1
+weight: 93
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 93
 ---
+
+{{% hasProbdata id=93 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=93 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2018/2.md
+++ b/content/ja/problems/IOL/2018/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2018-2 ハクン語"
-weight: 2
+weight: 94
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 94
 ---
+
+{{% hasProbdata id=94 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=94 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2018/3.md
+++ b/content/ja/problems/IOL/2018/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2018-3 テレナ語"
-weight: 3
+weight: 95
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 95
 ---
+
+{{% hasProbdata id=95 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=95 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2018/4.md
+++ b/content/ja/problems/IOL/2018/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2018-4 山岳アラペシュ（ブキイプ語）"
-weight: 4
+weight: 96
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 96
 ---
+
+{{% hasProbdata id=96 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=96 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2018/5.md
+++ b/content/ja/problems/IOL/2018/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2018-5 アカン語"
-weight: 5
+weight: 97
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 97
 ---
+
+{{% hasProbdata id=97 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=97 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2018/team-1.md
+++ b/content/ja/problems/IOL/2018/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2018-team-1 メンベンゴクレ語，シャバンチ語，クリンカチー語"
-weight: 991
+weight: 98
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 98
 ---
+
+{{% hasProbdata id=98 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=98 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2019/1.md
+++ b/content/ja/problems/IOL/2019/1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2019-1 ヨンゴム語"
-weight: 1
+weight: 99
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 99
 ---
+
+{{% hasProbdata id=99 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=99 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2019/2.md
+++ b/content/ja/problems/IOL/2019/2.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2019-2 ユロック語"
-weight: 2
+weight: 100
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 100
 ---
+
+{{% hasProbdata id=100 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=100 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2019/3.md
+++ b/content/ja/problems/IOL/2019/3.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2019-3 書物のパフラヴィー文字"
-weight: 3
+weight: 101
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 101
 ---
+
+{{% hasProbdata id=101 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=101 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2019/4.md
+++ b/content/ja/problems/IOL/2019/4.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2019-4 西タランガン語"
-weight: 4
+weight: 102
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 102
 ---
+
+{{% hasProbdata id=102 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=102 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2019/5.md
+++ b/content/ja/problems/IOL/2019/5.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2019-5 ノニ語"
-weight: 5
+weight: 103
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 103
 ---
+
+{{% hasProbdata id=103 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=103 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/2019/team-1.md
+++ b/content/ja/problems/IOL/2019/team-1.md
@@ -1,12 +1,18 @@
 ---
 title: "IOL2019-team-1 新体操"
-weight: 991
+weight: 104
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 104
 ---
+
+{{% hasProbdata id=104 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=104 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/IOL/sample/easy-1.md
+++ b/content/ja/problems/IOL/sample/easy-1.md
@@ -8,6 +8,12 @@ problems:
 - 278
 ---
 
+{{% hasProbdata id=278 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=278 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=278 detailed=true %}}{{% hasProbdata id=278 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/easy-2.md
+++ b/content/ja/problems/IOL/sample/easy-2.md
@@ -8,6 +8,12 @@ problems:
 - 279
 ---
 
+{{% hasProbdata id=279 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=279 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=279 detailed=true %}}{{% hasProbdata id=279 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/easy-3.md
+++ b/content/ja/problems/IOL/sample/easy-3.md
@@ -8,6 +8,12 @@ problems:
 - 280
 ---
 
+{{% hasProbdata id=280 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=280 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=280 detailed=true %}}{{% hasProbdata id=280 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/easy-4.md
+++ b/content/ja/problems/IOL/sample/easy-4.md
@@ -8,6 +8,12 @@ problems:
 - 281
 ---
 
+{{% hasProbdata id=281 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=281 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=281 detailed=true %}}{{% hasProbdata id=281 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/easy-5.md
+++ b/content/ja/problems/IOL/sample/easy-5.md
@@ -8,6 +8,12 @@ problems:
 - 282
 ---
 
+{{% hasProbdata id=282 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=282 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=282 detailed=true %}}{{% hasProbdata id=282 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/easy-6.md
+++ b/content/ja/problems/IOL/sample/easy-6.md
@@ -8,6 +8,12 @@ problems:
 - 283
 ---
 
+{{% hasProbdata id=283 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=283 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=283 detailed=true %}}{{% hasProbdata id=283 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/easy-7.md
+++ b/content/ja/problems/IOL/sample/easy-7.md
@@ -8,6 +8,12 @@ problems:
 - 284
 ---
 
+{{% hasProbdata id=284 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=284 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=284 detailed=true %}}{{% hasProbdata id=284 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/hard-1.md
+++ b/content/ja/problems/IOL/sample/hard-1.md
@@ -8,6 +8,12 @@ problems:
 - 291
 ---
 
+{{% hasProbdata id=291 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=291 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=291 detailed=true %}}{{% hasProbdata id=291 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/hard-2.md
+++ b/content/ja/problems/IOL/sample/hard-2.md
@@ -8,6 +8,12 @@ problems:
 - 292
 ---
 
+{{% hasProbdata id=292 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=292 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=292 detailed=true %}}{{% hasProbdata id=292 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/hard-3.md
+++ b/content/ja/problems/IOL/sample/hard-3.md
@@ -8,6 +8,12 @@ problems:
 - 293
 ---
 
+{{% hasProbdata id=293 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=293 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=293 detailed=true %}}{{% hasProbdata id=293 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/hard-4.md
+++ b/content/ja/problems/IOL/sample/hard-4.md
@@ -8,6 +8,12 @@ problems:
 - 294
 ---
 
+{{% hasProbdata id=294 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=294 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=294 detailed=true %}}{{% hasProbdata id=294 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/hard-5.md
+++ b/content/ja/problems/IOL/sample/hard-5.md
@@ -8,6 +8,12 @@ problems:
 - 295
 ---
 
+{{% hasProbdata id=295 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=295 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=295 detailed=true %}}{{% hasProbdata id=295 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/intermediate-1.md
+++ b/content/ja/problems/IOL/sample/intermediate-1.md
@@ -8,6 +8,12 @@ problems:
 - 285
 ---
 
+{{% hasProbdata id=285 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=285 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=285 detailed=true %}}{{% hasProbdata id=285 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/intermediate-2.md
+++ b/content/ja/problems/IOL/sample/intermediate-2.md
@@ -8,6 +8,12 @@ problems:
 - 286
 ---
 
+{{% hasProbdata id=286 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=286 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=286 detailed=true %}}{{% hasProbdata id=286 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/intermediate-3.md
+++ b/content/ja/problems/IOL/sample/intermediate-3.md
@@ -8,6 +8,12 @@ problems:
 - 287
 ---
 
+{{% hasProbdata id=287 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=287 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=287 detailed=true %}}{{% hasProbdata id=287 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/intermediate-4.md
+++ b/content/ja/problems/IOL/sample/intermediate-4.md
@@ -8,6 +8,12 @@ problems:
 - 288
 ---
 
+{{% hasProbdata id=288 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=288 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=288 detailed=true %}}{{% hasProbdata id=288 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/intermediate-5.md
+++ b/content/ja/problems/IOL/sample/intermediate-5.md
@@ -8,6 +8,12 @@ problems:
 - 289
 ---
 
+{{% hasProbdata id=289 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=289 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=289 detailed=true %}}{{% hasProbdata id=289 key="probcorrection" %}}

--- a/content/ja/problems/IOL/sample/intermediate-6.md
+++ b/content/ja/problems/IOL/sample/intermediate-6.md
@@ -8,6 +8,12 @@ problems:
 - 290
 ---
 
+{{% hasProbdata id=290 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=290 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=290 detailed=true %}}{{% hasProbdata id=290 key="probcorrection" %}}

--- a/content/ja/problems/_index.md
+++ b/content/ja/problems/_index.md
@@ -7,6 +7,7 @@ menu:
   main:
     weight: 30
 description: "問題の一覧．難易度やジャンルで絞り込める機能つき．[取説](about/)"
+database: true
 ---
 
 {{% database %}}

--- a/content/ja/problems/_index.md
+++ b/content/ja/problems/_index.md
@@ -6,8 +6,16 @@ type: docs
 menu:
   main:
     weight: 30
-description: "問題の一覧．難易度やジャンルで絞り込める機能つき．[取説](about/)"
+description: "問題の一覧．難易度やジャンルで絞り込める機能つき．"
 database: true
 ---
+
+{{< wrap tag="p" class="mb-4" >}}
+{{< list aclass="card-link" >}}
+[取説](about/)
+[統計](statistics/)
+[大会一覧](contests/)
+{{< /list >}}
+{{< /wrap >}}
 
 {{% database %}}

--- a/content/ja/problems/contests/_index.md
+++ b/content/ja/problems/contests/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "大会一覧"
 linkTitle: "大会一覧"
-weight: 2
+weight: 4
 type: docs
 description: "大会ごとの問題一覧"
 database: true

--- a/content/ja/problems/contests/_index.md
+++ b/content/ja/problems/contests/_index.md
@@ -1,0 +1,10 @@
+---
+title: "大会一覧"
+linkTitle: "大会一覧"
+weight: 2
+type: docs
+description: "大会ごとの問題一覧"
+database: true
+---
+
+{{< database-contests >}}

--- a/content/ja/problems/jol/2017/1.md
+++ b/content/ja/problems/jol/2017/1.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2017-1 ロシア語"
-weight: 1
+weight: 110
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 110
 ---
+
+{{% hasProbdata id=110 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=110 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2017/2.md
+++ b/content/ja/problems/jol/2017/2.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2017-2 フリウリ語"
-weight: 2
+weight: 111
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 111
 ---
+
+{{% hasProbdata id=111 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=111 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2017/3.md
+++ b/content/ja/problems/jol/2017/3.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2017-3 モンゴル語"
-weight: 3
+weight: 112
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 112
 ---
+
+{{% hasProbdata id=112 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=112 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2018/1.md
+++ b/content/ja/problems/jol/2018/1.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2018-1 英語，チェコ語，ポーランド語，スウェーデン語"
-weight: 1
+weight: 113
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 113
 ---
+
+{{% hasProbdata id=113 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=113 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2018/2.md
+++ b/content/ja/problems/jol/2018/2.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2018-2 ベジャ語"
-weight: 2
+weight: 114
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 114
 ---
+
+{{% hasProbdata id=114 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=114 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2018/3.md
+++ b/content/ja/problems/jol/2018/3.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2018-3 ナーナイ語"
-weight: 3
+weight: 115
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 115
 ---
+
+{{% hasProbdata id=115 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=115 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2018/4.md
+++ b/content/ja/problems/jol/2018/4.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2018-4 オルホン文字/古テュルク語"
-weight: 4
+weight: 116
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 116
 ---
+
+{{% hasProbdata id=116 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=116 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2018/5.md
+++ b/content/ja/problems/jol/2018/5.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2018-5 モンゴル語とチベット語"
-weight: 5
+weight: 117
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 117
 ---
+
+{{% hasProbdata id=117 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=117 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2019/1.md
+++ b/content/ja/problems/jol/2019/1.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2019-1 ハングル"
-weight: 1
+weight: 118
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 118
 ---
+
+{{% hasProbdata id=118 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=118 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2019/2.md
+++ b/content/ja/problems/jol/2019/2.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2019-2 国際音声記号"
-weight: 2
+weight: 119
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 119
 ---
+
+{{% hasProbdata id=119 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=119 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2019/3.md
+++ b/content/ja/problems/jol/2019/3.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2019-3 フィンランド語"
-weight: 3
+weight: 120
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 120
 ---
+
+{{% hasProbdata id=120 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=120 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2019/4.md
+++ b/content/ja/problems/jol/2019/4.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2019-4 イヌクティトゥット語"
-weight: 4
+weight: 121
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 121
 ---
+
+{{% hasProbdata id=121 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=121 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2019/5.md
+++ b/content/ja/problems/jol/2019/5.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2019-5 コリマ・ユカギール語"
-weight: 5
+weight: 122
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 122
 ---
+
+{{% hasProbdata id=122 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=122 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2020/1.md
+++ b/content/ja/problems/jol/2020/1.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2020-1 アラビア文字/アラビア語"
-weight: 1
+weight: 123
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 123
 ---
+
+{{% hasProbdata id=123 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=123 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2020/2.md
+++ b/content/ja/problems/jol/2020/2.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2020-2 エウェンキ語，オロチ語，ナーナイ語"
-weight: 2
+weight: 124
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 124
 ---
+
+{{% hasProbdata id=124 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=124 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2020/3.md
+++ b/content/ja/problems/jol/2020/3.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2020-3 バスク語"
-weight: 3
+weight: 125
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 125
 ---
+
+{{% hasProbdata id=125 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=125 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2020/4.md
+++ b/content/ja/problems/jol/2020/4.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2020-4 リヴォニア語"
-weight: 4
+weight: 126
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 126
 ---
+
+{{% hasProbdata id=126 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=126 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/2020/5.md
+++ b/content/ja/problems/jol/2020/5.md
@@ -1,12 +1,18 @@
 ---
 title: "JOL2020-5 ウルドゥー語"
-weight: 5
+weight: 127
 type: docs
 pagetype: prob
 description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 127
 ---
+
+{{% hasProbdata id=127 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=127 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/jol/sample/1.md
+++ b/content/ja/problems/jol/sample/1.md
@@ -8,6 +8,12 @@ problems:
 - 274
 ---
 
+{{% hasProbdata id=274 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=274 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=274 detailed=true %}}{{% hasProbdata id=274 key="probcorrection" %}}

--- a/content/ja/problems/jol/sample/2.md
+++ b/content/ja/problems/jol/sample/2.md
@@ -8,6 +8,12 @@ problems:
 - 275
 ---
 
+{{% hasProbdata id=275 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=275 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=275 detailed=true %}}{{% hasProbdata id=275 key="probcorrection" %}}

--- a/content/ja/problems/jol/sample/3.md
+++ b/content/ja/problems/jol/sample/3.md
@@ -8,6 +8,12 @@ problems:
 - 276
 ---
 
+{{% hasProbdata id=276 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=276 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=276 detailed=true %}}{{% hasProbdata id=276 key="probcorrection" %}}

--- a/content/ja/problems/jol/sample/4.md
+++ b/content/ja/problems/jol/sample/4.md
@@ -8,6 +8,12 @@ problems:
 - 277
 ---
 
+{{% hasProbdata id=277 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=277 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=277 detailed=true %}}{{% hasProbdata id=277 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2010/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 128
 ---
 
+{{% hasProbdata id=128 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=128 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=128 detailed=true %}}{{% hasProbdata id=128 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2010/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 129
 ---
 
+{{% hasProbdata id=129 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=129 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=129 detailed=true %}}{{% hasProbdata id=129 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2010/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 130
 ---
 
+{{% hasProbdata id=130 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=130 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=130 detailed=true %}}{{% hasProbdata id=130 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2010/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 131
 ---
 
+{{% hasProbdata id=131 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=131 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=131 detailed=true %}}{{% hasProbdata id=131 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2010/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 132
 ---
 
+{{% hasProbdata id=132 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=132 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=132 detailed=true %}}{{% hasProbdata id=132 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2010/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 133
 ---
 
+{{% hasProbdata id=133 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=133 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=133 detailed=true %}}{{% hasProbdata id=133 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2010/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 134
 ---
 
+{{% hasProbdata id=134 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=134 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=134 detailed=true %}}{{% hasProbdata id=134 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2010/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 135
 ---
 
+{{% hasProbdata id=135 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=135 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=135 detailed=true %}}{{% hasProbdata id=135 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2010/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 136
 ---
 
+{{% hasProbdata id=136 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=136 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=136 detailed=true %}}{{% hasProbdata id=136 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2010/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 137
 ---
 
+{{% hasProbdata id=137 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=137 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=137 detailed=true %}}{{% hasProbdata id=137 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2010/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 138
 ---
 
+{{% hasProbdata id=138 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=138 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=138 detailed=true %}}{{% hasProbdata id=138 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2010/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2010/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 139
 ---
 
+{{% hasProbdata id=139 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=139 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=139 detailed=true %}}{{% hasProbdata id=139 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2011/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 140
 ---
 
+{{% hasProbdata id=140 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=140 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=140 detailed=true %}}{{% hasProbdata id=140 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2011/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 141
 ---
 
+{{% hasProbdata id=141 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=141 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=141 detailed=true %}}{{% hasProbdata id=141 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2011/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 142
 ---
 
+{{% hasProbdata id=142 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=142 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=142 detailed=true %}}{{% hasProbdata id=142 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2011/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 143
 ---
 
+{{% hasProbdata id=143 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=143 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=143 detailed=true %}}{{% hasProbdata id=143 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2011/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 144
 ---
 
+{{% hasProbdata id=144 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=144 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=144 detailed=true %}}{{% hasProbdata id=144 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2011/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 145
 ---
 
+{{% hasProbdata id=145 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=145 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=145 detailed=true %}}{{% hasProbdata id=145 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2011/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 146
 ---
 
+{{% hasProbdata id=146 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=146 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=146 detailed=true %}}{{% hasProbdata id=146 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2011/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 147
 ---
 
+{{% hasProbdata id=147 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=147 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=147 detailed=true %}}{{% hasProbdata id=147 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2011/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 148
 ---
 
+{{% hasProbdata id=148 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=148 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=148 detailed=true %}}{{% hasProbdata id=148 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2011/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2011/r2-3.md
@@ -1,5 +1,5 @@
 ---
-title: "UKLO2011-R2-3 A script for the Ndyuka"
+title: "UKLO2011-R2-3 Axolotl in the water"
 weight: 149
 type: docs
 pagetype: prob
@@ -7,6 +7,12 @@ description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 149
 ---
+
+{{% hasProbdata id=149 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=149 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/oversea/uklo/2011/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2011/r2-4.md
@@ -1,5 +1,5 @@
 ---
-title: "UKLO2011-R2-4 Axolotl in the water"
+title: "UKLO2011-R2-4 A script for the Ndyuka"
 weight: 150
 type: docs
 pagetype: prob
@@ -7,6 +7,12 @@ description: "翻訳・ヒント・解答・解説のまとめ"
 problems: 
 - 150
 ---
+
+{{% hasProbdata id=150 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=150 %}}{{% /hasProbdata %}}
 
 ## 情報
 

--- a/content/ja/problems/oversea/uklo/2011/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2011/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 151
 ---
 
+{{% hasProbdata id=151 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=151 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=151 detailed=true %}}{{% hasProbdata id=151 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 152
 ---
 
+{{% hasProbdata id=152 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=152 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=152 detailed=true %}}{{% hasProbdata id=152 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 153
 ---
 
+{{% hasProbdata id=153 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=153 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=153 detailed=true %}}{{% hasProbdata id=153 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-3d.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-3d.md
@@ -8,6 +8,12 @@ problems:
 - 154
 ---
 
+{{% hasProbdata id=154 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=154 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=154 detailed=true %}}{{% hasProbdata id=154 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-3w.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-3w.md
@@ -8,6 +8,12 @@ problems:
 - 155
 ---
 
+{{% hasProbdata id=155 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=155 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=155 detailed=true %}}{{% hasProbdata id=155 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 156
 ---
 
+{{% hasProbdata id=156 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=156 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=156 detailed=true %}}{{% hasProbdata id=156 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 157
 ---
 
+{{% hasProbdata id=157 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=157 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=157 detailed=true %}}{{% hasProbdata id=157 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 158
 ---
 
+{{% hasProbdata id=158 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=158 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=158 detailed=true %}}{{% hasProbdata id=158 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 159
 ---
 
+{{% hasProbdata id=159 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=159 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=159 detailed=true %}}{{% hasProbdata id=159 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 160
 ---
 
+{{% hasProbdata id=160 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=160 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=160 detailed=true %}}{{% hasProbdata id=160 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2012/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 161
 ---
 
+{{% hasProbdata id=161 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=161 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=161 detailed=true %}}{{% hasProbdata id=161 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2012/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 162
 ---
 
+{{% hasProbdata id=162 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=162 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=162 detailed=true %}}{{% hasProbdata id=162 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2012/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 163
 ---
 
+{{% hasProbdata id=163 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=163 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=163 detailed=true %}}{{% hasProbdata id=163 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2012/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 164
 ---
 
+{{% hasProbdata id=164 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=164 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=164 detailed=true %}}{{% hasProbdata id=164 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2012/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 165
 ---
 
+{{% hasProbdata id=165 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=165 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=165 detailed=true %}}{{% hasProbdata id=165 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2012/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2012/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 166
 ---
 
+{{% hasProbdata id=166 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=166 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=166 detailed=true %}}{{% hasProbdata id=166 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 167
 ---
 
+{{% hasProbdata id=167 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=167 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=167 detailed=true %}}{{% hasProbdata id=167 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 168
 ---
 
+{{% hasProbdata id=168 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=168 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=168 detailed=true %}}{{% hasProbdata id=168 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 169
 ---
 
+{{% hasProbdata id=169 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=169 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=169 detailed=true %}}{{% hasProbdata id=169 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-4a.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-4a.md
@@ -8,6 +8,12 @@ problems:
 - 170
 ---
 
+{{% hasProbdata id=170 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=170 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=170 detailed=true %}}{{% hasProbdata id=170 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-4s.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-4s.md
@@ -8,6 +8,12 @@ problems:
 - 171
 ---
 
+{{% hasProbdata id=171 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=171 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=171 detailed=true %}}{{% hasProbdata id=171 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 172
 ---
 
+{{% hasProbdata id=172 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=172 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=172 detailed=true %}}{{% hasProbdata id=172 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 173
 ---
 
+{{% hasProbdata id=173 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=173 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=173 detailed=true %}}{{% hasProbdata id=173 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 174
 ---
 
+{{% hasProbdata id=174 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=174 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=174 detailed=true %}}{{% hasProbdata id=174 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 175
 ---
 
+{{% hasProbdata id=175 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=175 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=175 detailed=true %}}{{% hasProbdata id=175 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2013/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 176
 ---
 
+{{% hasProbdata id=176 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=176 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=176 detailed=true %}}{{% hasProbdata id=176 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2013/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 177
 ---
 
+{{% hasProbdata id=177 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=177 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=177 detailed=true %}}{{% hasProbdata id=177 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2013/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 178
 ---
 
+{{% hasProbdata id=178 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=178 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=178 detailed=true %}}{{% hasProbdata id=178 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2013/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 179
 ---
 
+{{% hasProbdata id=179 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=179 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=179 detailed=true %}}{{% hasProbdata id=179 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2013/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 180
 ---
 
+{{% hasProbdata id=180 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=180 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=180 detailed=true %}}{{% hasProbdata id=180 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2013/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2013/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 181
 ---
 
+{{% hasProbdata id=181 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=181 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=181 detailed=true %}}{{% hasProbdata id=181 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 182
 ---
 
+{{% hasProbdata id=182 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=182 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=182 detailed=true %}}{{% hasProbdata id=182 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 183
 ---
 
+{{% hasProbdata id=183 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=183 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=183 detailed=true %}}{{% hasProbdata id=183 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 184
 ---
 
+{{% hasProbdata id=184 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=184 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=184 detailed=true %}}{{% hasProbdata id=184 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 185
 ---
 
+{{% hasProbdata id=185 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=185 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=185 detailed=true %}}{{% hasProbdata id=185 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 186
 ---
 
+{{% hasProbdata id=186 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=186 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=186 detailed=true %}}{{% hasProbdata id=186 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 187
 ---
 
+{{% hasProbdata id=187 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=187 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=187 detailed=true %}}{{% hasProbdata id=187 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 188
 ---
 
+{{% hasProbdata id=188 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=188 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=188 detailed=true %}}{{% hasProbdata id=188 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 189
 ---
 
+{{% hasProbdata id=189 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=189 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=189 detailed=true %}}{{% hasProbdata id=189 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2014/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 190
 ---
 
+{{% hasProbdata id=190 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=190 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=190 detailed=true %}}{{% hasProbdata id=190 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2014/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 191
 ---
 
+{{% hasProbdata id=191 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=191 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=191 detailed=true %}}{{% hasProbdata id=191 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2014/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 192
 ---
 
+{{% hasProbdata id=192 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=192 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=192 detailed=true %}}{{% hasProbdata id=192 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2014/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 193
 ---
 
+{{% hasProbdata id=193 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=193 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=193 detailed=true %}}{{% hasProbdata id=193 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2014/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 194
 ---
 
+{{% hasProbdata id=194 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=194 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=194 detailed=true %}}{{% hasProbdata id=194 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2014/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2014/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 195
 ---
 
+{{% hasProbdata id=195 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=195 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=195 detailed=true %}}{{% hasProbdata id=195 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 196
 ---
 
+{{% hasProbdata id=196 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=196 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=196 detailed=true %}}{{% hasProbdata id=196 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-10.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-10.md
@@ -8,6 +8,12 @@ problems:
 - 205
 ---
 
+{{% hasProbdata id=205 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=205 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=205 detailed=true %}}{{% hasProbdata id=205 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 197
 ---
 
+{{% hasProbdata id=197 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=197 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=197 detailed=true %}}{{% hasProbdata id=197 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 198
 ---
 
+{{% hasProbdata id=198 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=198 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=198 detailed=true %}}{{% hasProbdata id=198 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 199
 ---
 
+{{% hasProbdata id=199 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=199 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=199 detailed=true %}}{{% hasProbdata id=199 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 200
 ---
 
+{{% hasProbdata id=200 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=200 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=200 detailed=true %}}{{% hasProbdata id=200 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 201
 ---
 
+{{% hasProbdata id=201 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=201 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=201 detailed=true %}}{{% hasProbdata id=201 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 202
 ---
 
+{{% hasProbdata id=202 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=202 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=202 detailed=true %}}{{% hasProbdata id=202 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 203
 ---
 
+{{% hasProbdata id=203 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=203 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=203 detailed=true %}}{{% hasProbdata id=203 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2015/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 204
 ---
 
+{{% hasProbdata id=204 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=204 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=204 detailed=true %}}{{% hasProbdata id=204 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2015/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 206
 ---
 
+{{% hasProbdata id=206 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=206 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=206 detailed=true %}}{{% hasProbdata id=206 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2015/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 207
 ---
 
+{{% hasProbdata id=207 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=207 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=207 detailed=true %}}{{% hasProbdata id=207 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2015/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 208
 ---
 
+{{% hasProbdata id=208 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=208 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=208 detailed=true %}}{{% hasProbdata id=208 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2015/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 209
 ---
 
+{{% hasProbdata id=209 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=209 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=209 detailed=true %}}{{% hasProbdata id=209 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2015/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2015/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 210
 ---
 
+{{% hasProbdata id=210 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=210 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=210 detailed=true %}}{{% hasProbdata id=210 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 211
 ---
 
+{{% hasProbdata id=211 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=211 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=211 detailed=true %}}{{% hasProbdata id=211 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-10.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-10.md
@@ -8,6 +8,12 @@ problems:
 - 220
 ---
 
+{{% hasProbdata id=220 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=220 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=220 detailed=true %}}{{% hasProbdata id=220 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 212
 ---
 
+{{% hasProbdata id=212 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=212 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=212 detailed=true %}}{{% hasProbdata id=212 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 213
 ---
 
+{{% hasProbdata id=213 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=213 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=213 detailed=true %}}{{% hasProbdata id=213 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 214
 ---
 
+{{% hasProbdata id=214 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=214 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=214 detailed=true %}}{{% hasProbdata id=214 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 215
 ---
 
+{{% hasProbdata id=215 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=215 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=215 detailed=true %}}{{% hasProbdata id=215 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 216
 ---
 
+{{% hasProbdata id=216 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=216 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=216 detailed=true %}}{{% hasProbdata id=216 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 217
 ---
 
+{{% hasProbdata id=217 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=217 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=217 detailed=true %}}{{% hasProbdata id=217 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 218
 ---
 
+{{% hasProbdata id=218 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=218 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=218 detailed=true %}}{{% hasProbdata id=218 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2016/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 219
 ---
 
+{{% hasProbdata id=219 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=219 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=219 detailed=true %}}{{% hasProbdata id=219 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2016/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 221
 ---
 
+{{% hasProbdata id=221 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=221 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=221 detailed=true %}}{{% hasProbdata id=221 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2016/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 222
 ---
 
+{{% hasProbdata id=222 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=222 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=222 detailed=true %}}{{% hasProbdata id=222 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2016/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 223
 ---
 
+{{% hasProbdata id=223 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=223 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=223 detailed=true %}}{{% hasProbdata id=223 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2016/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 224
 ---
 
+{{% hasProbdata id=224 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=224 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=224 detailed=true %}}{{% hasProbdata id=224 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2016/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2016/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 225
 ---
 
+{{% hasProbdata id=225 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=225 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=225 detailed=true %}}{{% hasProbdata id=225 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 226
 ---
 
+{{% hasProbdata id=226 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=226 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=226 detailed=true %}}{{% hasProbdata id=226 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-10.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-10.md
@@ -8,6 +8,12 @@ problems:
 - 235
 ---
 
+{{% hasProbdata id=235 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=235 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=235 detailed=true %}}{{% hasProbdata id=235 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 227
 ---
 
+{{% hasProbdata id=227 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=227 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=227 detailed=true %}}{{% hasProbdata id=227 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 228
 ---
 
+{{% hasProbdata id=228 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=228 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=228 detailed=true %}}{{% hasProbdata id=228 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 229
 ---
 
+{{% hasProbdata id=229 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=229 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=229 detailed=true %}}{{% hasProbdata id=229 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 230
 ---
 
+{{% hasProbdata id=230 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=230 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=230 detailed=true %}}{{% hasProbdata id=230 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 231
 ---
 
+{{% hasProbdata id=231 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=231 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=231 detailed=true %}}{{% hasProbdata id=231 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 232
 ---
 
+{{% hasProbdata id=232 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=232 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=232 detailed=true %}}{{% hasProbdata id=232 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 233
 ---
 
+{{% hasProbdata id=233 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=233 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=233 detailed=true %}}{{% hasProbdata id=233 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2017/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 234
 ---
 
+{{% hasProbdata id=234 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=234 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=234 detailed=true %}}{{% hasProbdata id=234 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2017/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 236
 ---
 
+{{% hasProbdata id=236 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=236 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=236 detailed=true %}}{{% hasProbdata id=236 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2017/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 237
 ---
 
+{{% hasProbdata id=237 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=237 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=237 detailed=true %}}{{% hasProbdata id=237 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2017/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 238
 ---
 
+{{% hasProbdata id=238 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=238 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=238 detailed=true %}}{{% hasProbdata id=238 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2017/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 239
 ---
 
+{{% hasProbdata id=239 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=239 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=239 detailed=true %}}{{% hasProbdata id=239 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2017/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2017/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 240
 ---
 
+{{% hasProbdata id=240 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=240 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=240 detailed=true %}}{{% hasProbdata id=240 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 241
 ---
 
+{{% hasProbdata id=241 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=241 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=241 detailed=true %}}{{% hasProbdata id=241 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-10.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-10.md
@@ -8,6 +8,12 @@ problems:
 - 250
 ---
 
+{{% hasProbdata id=250 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=250 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=250 detailed=true %}}{{% hasProbdata id=250 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 242
 ---
 
+{{% hasProbdata id=242 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=242 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=242 detailed=true %}}{{% hasProbdata id=242 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 243
 ---
 
+{{% hasProbdata id=243 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=243 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=243 detailed=true %}}{{% hasProbdata id=243 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 244
 ---
 
+{{% hasProbdata id=244 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=244 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=244 detailed=true %}}{{% hasProbdata id=244 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 245
 ---
 
+{{% hasProbdata id=245 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=245 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=245 detailed=true %}}{{% hasProbdata id=245 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 246
 ---
 
+{{% hasProbdata id=246 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=246 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=246 detailed=true %}}{{% hasProbdata id=246 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 247
 ---
 
+{{% hasProbdata id=247 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=247 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=247 detailed=true %}}{{% hasProbdata id=247 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 248
 ---
 
+{{% hasProbdata id=248 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=248 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=248 detailed=true %}}{{% hasProbdata id=248 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2018/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 249
 ---
 
+{{% hasProbdata id=249 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=249 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=249 detailed=true %}}{{% hasProbdata id=249 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2018/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 251
 ---
 
+{{% hasProbdata id=251 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=251 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=251 detailed=true %}}{{% hasProbdata id=251 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2018/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 252
 ---
 
+{{% hasProbdata id=252 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=252 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=252 detailed=true %}}{{% hasProbdata id=252 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2018/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 253
 ---
 
+{{% hasProbdata id=253 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=253 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=253 detailed=true %}}{{% hasProbdata id=253 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2018/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 254
 ---
 
+{{% hasProbdata id=254 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=254 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=254 detailed=true %}}{{% hasProbdata id=254 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2018/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2018/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 255
 ---
 
+{{% hasProbdata id=255 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=255 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=255 detailed=true %}}{{% hasProbdata id=255 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-1.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-1.md
@@ -8,6 +8,12 @@ problems:
 - 256
 ---
 
+{{% hasProbdata id=256 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=256 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=256 detailed=true %}}{{% hasProbdata id=256 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-10.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-10.md
@@ -8,6 +8,12 @@ problems:
 - 265
 ---
 
+{{% hasProbdata id=265 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=265 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=265 detailed=true %}}{{% hasProbdata id=265 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-2.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-2.md
@@ -8,6 +8,12 @@ problems:
 - 257
 ---
 
+{{% hasProbdata id=257 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=257 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=257 detailed=true %}}{{% hasProbdata id=257 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-3.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-3.md
@@ -8,6 +8,12 @@ problems:
 - 258
 ---
 
+{{% hasProbdata id=258 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=258 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=258 detailed=true %}}{{% hasProbdata id=258 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-4.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-4.md
@@ -8,6 +8,12 @@ problems:
 - 259
 ---
 
+{{% hasProbdata id=259 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=259 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=259 detailed=true %}}{{% hasProbdata id=259 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-5.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-5.md
@@ -8,6 +8,12 @@ problems:
 - 260
 ---
 
+{{% hasProbdata id=260 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=260 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=260 detailed=true %}}{{% hasProbdata id=260 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-6.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-6.md
@@ -8,6 +8,12 @@ problems:
 - 261
 ---
 
+{{% hasProbdata id=261 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=261 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=261 detailed=true %}}{{% hasProbdata id=261 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-7.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-7.md
@@ -8,6 +8,12 @@ problems:
 - 262
 ---
 
+{{% hasProbdata id=262 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=262 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=262 detailed=true %}}{{% hasProbdata id=262 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-8.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-8.md
@@ -8,6 +8,12 @@ problems:
 - 263
 ---
 
+{{% hasProbdata id=263 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=263 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=263 detailed=true %}}{{% hasProbdata id=263 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r1-9.md
+++ b/content/ja/problems/oversea/uklo/2019/r1-9.md
@@ -8,6 +8,12 @@ problems:
 - 264
 ---
 
+{{% hasProbdata id=264 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=264 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=264 detailed=true %}}{{% hasProbdata id=264 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r2-1.md
+++ b/content/ja/problems/oversea/uklo/2019/r2-1.md
@@ -8,6 +8,12 @@ problems:
 - 266
 ---
 
+{{% hasProbdata id=266 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=266 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=266 detailed=true %}}{{% hasProbdata id=266 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r2-2.md
+++ b/content/ja/problems/oversea/uklo/2019/r2-2.md
@@ -8,6 +8,12 @@ problems:
 - 267
 ---
 
+{{% hasProbdata id=267 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=267 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=267 detailed=true %}}{{% hasProbdata id=267 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r2-3.md
+++ b/content/ja/problems/oversea/uklo/2019/r2-3.md
@@ -8,6 +8,12 @@ problems:
 - 268
 ---
 
+{{% hasProbdata id=268 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=268 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=268 detailed=true %}}{{% hasProbdata id=268 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r2-4.md
+++ b/content/ja/problems/oversea/uklo/2019/r2-4.md
@@ -8,6 +8,12 @@ problems:
 - 269
 ---
 
+{{% hasProbdata id=269 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=269 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=269 detailed=true %}}{{% hasProbdata id=269 key="probcorrection" %}}

--- a/content/ja/problems/oversea/uklo/2019/r2-5.md
+++ b/content/ja/problems/oversea/uklo/2019/r2-5.md
@@ -8,6 +8,12 @@ problems:
 - 270
 ---
 
+{{% hasProbdata id=270 key="introduction" %}}
+
+## 紹介
+
+{{% problems/introduction id=270 %}}{{% /hasProbdata %}}
+
 ## 情報
 
 {{% problems/probcard id=270 detailed=true %}}{{% hasProbdata id=270 key="probcorrection" %}}

--- a/content/ja/problems/statistics/_index.md
+++ b/content/ja/problems/statistics/_index.md
@@ -1,0 +1,10 @@
+---
+title: "統計"
+linkTitle: "統計"
+weight: 3
+type: docs
+description: "どんな問題がどれくらいあるか"
+charts: true
+---
+
+{{< database-charts >}}

--- a/data/contests.json
+++ b/data/contests.json
@@ -1,0 +1,267 @@
+[
+    {
+        "id": 1,
+        "venue": "IOL",
+        "year": 2003,
+        "prob": "https://ioling.org/booklets/iol-2003-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2003-indiv-sol.en.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2003-team-prob.en.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2003-team-sol.en.pdf"
+    },
+    {
+        "id": 2,
+        "venue": "IOL",
+        "year": 2004,
+        "prob": "https://ioling.org/booklets/iol-2004-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2004-indiv-sol.en.pdf"
+    },
+    {
+        "id": 3,
+        "venue": "IOL",
+        "year": 2005,
+        "prob": "https://ioling.org/booklets/iol-2005-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2005-indiv-sol.en.pdf"
+    },
+    {
+        "id": 4,
+        "venue": "IOL",
+        "year": 2006,
+        "prob": "https://ioling.org/booklets/iol-2006-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2006-indiv-sol.en.pdf"
+    },
+    {
+        "id": 5,
+        "venue": "IOL",
+        "year": 2007,
+        "prob": "https://ioling.org/booklets/iol-2007-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2007-indiv-sol.en.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2007-team-prob.en.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2007-team-sol.m.pdf"
+    },
+    {
+        "id": 6,
+        "venue": "IOL",
+        "year": 2008,
+        "prob": "https://ioling.org/booklets/iol-2008-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2008-indiv-sol.en-us.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2008-team-prob.en-us.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2008-team-sol.en.pdf"
+    },
+    {
+        "id": 7,
+        "venue": "IOL",
+        "year": 2009,
+        "prob": "https://ioling.org/booklets/iol-2009-indiv-prob.en-us.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2009-indiv-sol.en.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2009-team-prob.en.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2009-team-sol.en.pdf"
+    },
+    {
+        "id": 8,
+        "venue": "IOL",
+        "year": 2010,
+        "prob": "https://ioling.org/booklets/iol-2010-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2010-indiv-sol.en.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2010-team-prob.en.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2010-team-sol.en.pdf"
+    },
+    {
+        "id": 9,
+        "venue": "IOL",
+        "year": 2011,
+        "prob": "https://ioling.org/booklets/iol-2011-indiv-prob.en-us.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2011-indiv-sol.en-us.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2011-team-prob.en-us.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2011-team-sol.en-us.pdf"
+    },
+    {
+        "id": 10,
+        "venue": "IOL",
+        "year": 2012,
+        "prob": "https://ioling.org/booklets/iol-2012-indiv-prob.en.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2012-indiv-sol.en.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2012-team-prob.en.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2012-team-sol.en.pdf"
+    },
+    {
+        "id": 11,
+        "venue": "IOL",
+        "year": 2013,
+        "prob": "https://ioling.org/booklets/iol-2013-indiv-prob.en-us.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2013-indiv-sol.en-us.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2013-team-prob.en-us.pdf"
+    },
+    {
+        "id": 12,
+        "venue": "IOL",
+        "year": 2014,
+        "prob": "https://ioling.org/booklets/iol-2014-indiv-prob.ja.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2014-indiv-sol.ja.pdf"
+    },
+    {
+        "id": 13,
+        "venue": "IOL",
+        "year": 2015,
+        "prob": "https://ioling.org/booklets/iol-2015-indiv-prob.ja.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2015-indiv-sol.ja.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2015-team-prob.ja.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2015-team-sol.ja.pdf"
+    },
+    {
+        "id": 14,
+        "venue": "IOL",
+        "year": 2016,
+        "prob": "https://ioling.org/booklets/iol-2016-indiv-prob.ja.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2016-indiv-sol.ja.pdf"
+    },
+    {
+        "id": 15,
+        "venue": "IOL",
+        "year": 2017,
+        "prob": "https://ioling.org/booklets/iol-2017-indiv-prob.ja.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2017-indiv-sol.ja.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2017-team-prob.ja.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2017-team-sol.ja.pdf"
+    },
+    {
+        "id": 16,
+        "venue": "IOL",
+        "year": 2018,
+        "prob": "https://ioling.org/booklets/iol-2018-indiv-prob.ja.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2018-indiv-sol.ja.pdf",
+        "teamprob": "https://ioling.org/booklets/iol-2018-team-prob.ja.pdf",
+        "teamsol": "https://ioling.org/booklets/iol-2018-team-sol.ja.pdf"
+    },
+    {
+        "id": 17,
+        "venue": "IOL",
+        "year": 2019,
+        "prob": "https://ioling.org/booklets/iol-2019-indiv-prob.ja.pdf",
+        "probsol": "https://ioling.org/booklets/iol-2019-indiv-sol.ja.pdf"
+    },
+    {
+        "id": 18,
+        "venue": "APLO",
+        "year": 2019,
+        "prob": "https://drive.google.com/file/d/1kUJr2BAg7WaA-e7qhLqENC3PfPxrD0gW/view",
+        "probsol": "https://drive.google.com/file/d/1I7DKVv8o22M-csddn5upRUt7YXs4MVvu/view"
+    },
+    {
+        "id": 19,
+        "venue": "JOL",
+        "year": 2017,
+        "prob": "https://drive.google.com/file/d/1DSG3MISTszSPeMeG-VmnyKA0kFe7iywZ/view",
+        "probsol": "https://drive.google.com/file/d/1GSyrZ7f6hvOAQ3sc19mFAOzRlUYK0W0q/view"
+    },
+    {
+        "id": 20,
+        "venue": "JOL",
+        "year": 2018,
+        "prob": "https://drive.google.com/file/d/17anbddEBxNaZe_kDGRQPxvpzlR1lMYb2/view",
+        "probsol": "http://zohe.hatenablog.com/entry/2019/03/04/145808"
+    },
+    {
+        "id": 21,
+        "venue": "JOL",
+        "year": 2019,
+        "prob": "https://drive.google.com/file/d/1BjNVq20Ne9LVAqGEa9nLPsF9FhuhDjAA/view",
+        "probsol": "https://drive.google.com/open?id=1-lHLG82BcwZSuWnCuXD8GwTXFS2vv_Lh"
+    },
+    {
+        "id": 22,
+        "venue": "JOL",
+        "year": 2020,
+        "prob": "https://drive.google.com/file/d/1FPhk59e8A0FIXgOliitzg1qU95V7fppV/view",
+        "probsol": "https://drive.google.com/open?id=1EWBp7YEriz4L6cCEkiqeDwo5ku-qh-ic"
+    },
+    {
+        "id": 23,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2010,
+        "prob": "https://www.uklo.org/2010-2/uklo-2010"
+    },
+    {
+        "id": 24,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2011,
+        "prob": "https://www.uklo.org/problems/uklo-tests-2011"
+    },
+    {
+        "id": 25,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2012,
+        "prob": "https://www.uklo.org/test-papers-2012"
+    },
+    {
+        "id": 26,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2013,
+        "prob": "https://www.uklo.org/test-papers-for-2013-retrospective"
+    },
+    {
+        "id": 27,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2014,
+        "prob": "https://www.uklo.org/papers-2014"
+    },
+    {
+        "id": 28,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2015,
+        "prob": "https://www.uklo.org/papers-2015-2"
+    },
+    {
+        "id": 29,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2016,
+        "prob": "https://www.uklo.org/problems-2016"
+    },
+    {
+        "id": 30,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2017,
+        "prob": "https://www.uklo.org/problems-2017"
+    },
+    {
+        "id": 31,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2018,
+        "prob": "https://www.uklo.org/problems-2018"
+    },
+    {
+        "id": 32,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2019,
+        "prob": "https://www.uklo.org/problems-2019"
+    },
+    {
+        "id": 33,
+        "venue": "JOL",
+        "year": -1,
+        "prob": "https://iolingjapan.org/sample-problems/"
+    },
+    {
+        "id": 34,
+        "venue": "IOL",
+        "year": -1,
+        "prob": "https://ioling.org/booklets/samples.en.pdf",
+        "probsol": "https://ioling.org/booklets/samples.solution.en.pdf"
+    },
+    {
+        "id": 35,
+        "venue": "UKLO",
+        "venuecompatiable": "oversea",
+        "year": 2020,
+        "prob": "https://www.uklo.org/problems-2020"
+    }
+]

--- a/data/problems.json
+++ b/data/problems.json
@@ -3111,23 +3111,28 @@
         "hint": {
             "name": "karngati",
             "value": [
-                "解答するためには語の種類，語の使い分けかた，語の並べかたが分かればよい．",
-                "\"to cusin\"「君のいとこ（単数）」，\"il nestri cusin irlandês\"「私たちのアイルランド人のいとこ」，\"i miei cusins\"「私のいとこ達」を比べると？",
-                "cusin, cusinsが「いとこ，いとこ達」などを意味することが分かる．",
-                "更にcjase/cjases，biciclete/bicicletes，sûr/sûrsを比べると？",
+                "\"to cusin\"「君のいとこ（単数）」，\"il nestri cusin irlandês\"「私たちのアイルランド人のいとこ」，\"i miei cusins\"「私のいとこ達」に共通するのは？",
+                "cusin, cusins「いとこ，いとこ達」が共通しており，この語の意味が分かる．",
+                "更にcjase/cjases，biciclete/bicicletes，sûr/sûrsが出てくる例を比べると？",
                 "語尾の-sが複数を意味することが分かる．",
-                "\"mê sûr\"「私の姉（単数）」, \"nestri fradi\"「私たちの兄（単数）」, \"to cusin\"「君のいとこ（単数）」の前半部分は何を意味している？",
-                "mê, nestri, toはそれぞれ「私の」「私たちの」「君の」を意味することが分かる．",
                 "フリウリ語のla, lisは何を表しているだろうか．\"lis cjases\",「その（特定の）家（複数）」， \"la biciclete\"「その（特定の）自転車（単数）」を手掛かりにすると？",
                 "la, lisは日本語訳の「その（特定の）」に当たり，英語のtheのような対象の定性を表す定冠詞だと想像できる．",
-                "更に分析を進めるために語の順番を考えよう．cjaseやcusinなどの中心となる語，mêなど「～～の」を表す語，定冠詞，irlandese/irlandêsはどのように並んでいる？",
-                "(定冠詞)-(所有者)-中心の名詞-(irlandese/irlandês) という順に並んでいる．",
-                "まだ機能の分からない語はi, il, tôs, nestris, gno, nestre, mieiである．これらの機能はは定冠詞，所有者のどれだろうか．語順に注目して考えよう．",
-                "il, iが定冠詞，tôs,が「君の」 ，nestris, nestreが「私たちの」， miei, gnoが「私の」を意味すると分かる．",
-                "ここで単語を整理しよう．</br>定冠詞……la, lis, i, il</br>「私の」……mê, gno, mês, miei</br>「私達の」……nestris, nestri, nestre</br>「君の」……tôs, to</br>まずｈlaだけに注目しよう．\"la mê cjase\"「私の家（単数）」，\"la biciclete\"「その（特定の）自転車（単数）」，\"la nestre ave irlandese\"「私たちのアイルランド人のおばあちゃん」に共通していることは？",
-                "いずれも中心となる名詞が単数である．同様に，ほかの定冠詞，所有者を表す部分も数に着目して分析しよう．",
-                "以下のようなことが分かる．<table> <tbody><tr> <th></th> <th>単数</th> <th>複数</th> </tr> <tr> <td>定冠詞　</td> <td>la, il</td> <td>lis, a</td> </tr> <tr> <td>私の</td> <td>mê, gno</td> <td>mês, miei</td> </tr> <tr> <td>私達の</td> <td>nestre, nestri　</td> <td>nestris</td> </tr> <tr> <td>君の</td> <td>to</td> <td>tôs</td> </tr> </tbody></table>",
-                "つぎにlaとi，meとgnoなどの使い分けかたを考えよう．"
+                "mêはどんな意味？",
+                "\"la mê cjase\"，\"mê sûr\"から「私の」だと分かる．",
+                "分析の手がかりとするため，語順を明らかにしよう．cjaseやcusinのような中心となる語（=日本語訳で一番後ろに来る語），mêのような所有者，定冠詞はどんな順番で並んでいる？また，それ以外の要素はある？",
+                "(定冠詞) - (所有者) - 名詞 の順に並んでいる．また，irlandese/irlandês「アイルランド人の」は最後に来る．",
+                "定冠詞，所有者のリストを作ろう．これらの機能は定冠詞，所有者のどれだろうか．語順に注目して考えよう．",
+                "| | |\n| - | - |\n|定冠詞|i, il, la, lis|\n|私の|gno, miei, mê, mês|\n|私達の|nestre, nestri, nestris|\n|君の|to, tôs|\nでは，これらの形はどのように使い分けられている？",
+                "たとえば定冠詞のlaを含む例，lisを含む例に注目し，それぞれの共通点を探そう．\n >| |  |\n >| - | - |\n >| la mê cjase | 私の家（単数）| \n>| la biciclete| その（特定の）自転車（単数）| \n>| la nestre ave irlandese | 私たちのアイルランド人のおばあちゃん |\n \n>|  |  | \n>| - | - | \n>| lis cjases| その（特定の）家（複数）| \n>| lis tôs bicicletes | 君の自転車（複数）| \n>| lis mês sûrs| 私の姉達| ",
+                "laは単数のとき，lisは複数のときに使われている．同様にほかの定冠詞，所有者を表す代名詞も数に着目して分析し，上のリストに単数/複数の軸を加えて表にまとめてみよう．",
+                "以下のような表が作れる．\n| | 単数 | 複数 |\n| - | - | - |\n|定冠詞| il, la| a, lis|\n|私の|gno, mê | miei, mês|\n|私達の| nestri, nestre| nestris|\n|君の|to |tôs |\n",
+                "さらに使い分けの条件を探そう．まずはilとlaが出てくる例の**形**を見ると？\n>| | | \n>| - | - | \n>|la mê cjase|私の家（単数）| \n>|la biciclete|私の自転車（単数）| \n>|la nestre ave irlandese|私達のアイルランド人のおばあちゃん| \n\n>||| \n>|-|-| \n>|il gno lavôr|私の仕事（単数）| \n>|il nestri cusin irladês|私達のアイルランド人のいとこ（単数）|",
+                "語末が-eのときはla，そうでないときはilが使われている．lisとi，meとgnoなどのペアもこれに基づいて調べてみよう．全てこの条件で説明できるだろうか．",
+                "e（複数のときはes）で終わるときとそうでないときで冠詞などが使い分けられているが，sûr(s)「姉（達）」は例外的にeで終わるグループと同じ形が使われている．\n| | | 単数| 複数| | - | - | - | - |\n|定冠詞| -e | la | lis | \n|  | その他 | il | i | \n|私の| -e | me | mês | \n| | その他 | gno | miei| \n|私達の | -e | nestre |  | \n| | その他 | nestri | nestris | \n|君の| -e | | | \n| | その他 | to | tôs|\nlaが使われるグループには「おばあちゃん」「姉」といった女性の名称，ilが使われるグループには「兄」「いとこ」などの女性以外の名称が含まれている．これはインド＝ヨーロッパ語族の言語によくみられる文法性に従ったグループ分けである．",
+                "irlandeseとirlandêsはどのように使い分けられている？",
+                "名詞の文法性によって使い分けられている．",
+                "いくつかの例では定冠詞が付いていない．どのような場合に定冠詞が付かないか？",
+                "中心となる名詞が親族名称であり，単数であり，かつ「アイルランド人の」によって修飾されていないときである．\nこれでフリウリ語への翻訳ができる．"
             ]
         },
         "draft": false
@@ -4542,6 +4547,9 @@
         "number": "R1-7",
         "topic": "Waorani",
         "author": "Drago Radev",
+        "category": [
+            "数式"
+        ],
         "difficulty": {
             "typical": 1,
             "typicalStar": 1
@@ -4576,6 +4584,19 @@
         "number": "R1-9",
         "topic": "Waanyi",
         "author": "Mary Laughren",
+        "category": [
+            "統語"
+        ],
+        "difficulty": {
+            "typical": 6,
+            "typicalStar": 6
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 6
+            }
+        ],
         "draft": false
     },
     {
@@ -4588,6 +4609,19 @@
         "number": "R2-1",
         "topic": "English",
         "author": "Patrick Littell",
+        "category": [
+            "非言語"
+        ],
+        "difficulty": {
+            "typical": 3,
+            "typicalStar": 3
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 3
+            }
+        ],
         "draft": false
     },
     {
@@ -4600,7 +4634,21 @@
         "number": "R2-2",
         "topic": "Luiseño",
         "author": "Ronald Langacker (via Dick Hudson)",
-        "draft": false
+        "category": [
+            "統語"
+        ],
+        "difficulty": {
+            "typical": 4,
+            "typicalStar": 4
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 4
+            }
+        ],
+        "draft": false,
+        "memo": "語順とか対格(?)について解答ではまったく指定されてない"
     },
     {
         "id": 164,
@@ -4612,6 +4660,19 @@
         "number": "R2-3",
         "topic": "English",
         "author": "James Pustejovsky, Patrick Littell",
+        "category": [
+            "意味"
+        ],
+        "difficulty": {
+            "typical": 2,
+            "typicalStar": 2
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 2
+            }
+        ],
         "draft": false
     },
     {
@@ -4636,6 +4697,20 @@
         "number": "R2-5",
         "topic": "Catalan",
         "author": "Boris Iomdin",
+        "category": [
+            "音韻",
+            "韻律"
+        ],
+        "difficulty": {
+            "typical": 6,
+            "typicalStar": 6
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 6
+            }
+        ],
         "draft": false
     },
     {
@@ -4648,6 +4723,19 @@
         "number": "R1-1",
         "topic": "English",
         "author": "Harold Somers",
+        "category": [
+            "統語"
+        ],
+        "difficulty": {
+            "typical": 1,
+            "typicalStar": 1
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 1
+            }
+        ],
         "draft": false
     },
     {
@@ -4660,6 +4748,19 @@
         "year": 2013,
         "number": "R1-2",
         "topic": "Isthmus Zapotex",
+        "category": [
+            "形態"
+        ],
+        "difficulty": {
+            "typical": 1,
+            "typicalStar": 1
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 1
+            }
+        ],
         "draft": false
     },
     {
@@ -4672,6 +4773,19 @@
         "number": "R1-3",
         "topic": "Pali",
         "author": "Babette Newsome",
+        "category": [
+            "統語"
+        ],
+        "difficulty": {
+            "typical": 2,
+            "typicalStar": 2
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 2
+            }
+        ],
         "draft": false
     },
     {
@@ -4684,6 +4798,19 @@
         "number": "R1-4a",
         "topic": "Arabic",
         "author": "David Palfreyman",
+        "category": [
+            "文字"
+        ],
+        "difficulty": {
+            "typical": 1,
+            "typicalStar": 1
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 1
+            }
+        ],
         "draft": false
     },
     {
@@ -4696,6 +4823,19 @@
         "number": "R1-4s",
         "topic": "English – Shavian",
         "author": "Babette Newsome",
+        "category": [
+            "文字"
+        ],
+        "difficulty": {
+            "typical": 1,
+            "typicalStar": 1
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 1
+            }
+        ],
         "draft": false
     },
     {
@@ -4708,6 +4848,20 @@
         "number": "R1-5",
         "topic": "Bulgarian",
         "author": "Bozhidar Bozhanov",
+        "category": [
+            "形態",
+            "命数"
+        ],
+        "difficulty": {
+            "typical": 1,
+            "typicalStar": 1
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 1
+            }
+        ],
         "draft": false
     },
     {
@@ -4720,6 +4874,19 @@
         "number": "R1-6",
         "topic": "English",
         "author": "Dick Hudson",
+        "category": [
+            "統語"
+        ],
+        "difficulty": {
+            "typical": 2,
+            "typicalStar": 2
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 2
+            }
+        ],
         "draft": false
     },
     {
@@ -4732,6 +4899,19 @@
         "number": "R1-7",
         "topic": "Phoenician",
         "author": "Harold Somers",
+        "category": [
+            "文字"
+        ],
+        "difficulty": {
+            "typical": 3,
+            "typicalStar": 3
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 3
+            }
+        ],
         "draft": false
     },
     {
@@ -4744,6 +4924,19 @@
         "number": "R1-8",
         "topic": "Dutch",
         "author": "Harold Somers",
+        "category": [
+            "音韻"
+        ],
+        "difficulty": {
+            "typical": 3,
+            "typicalStar": 3
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 3
+            }
+        ],
         "draft": false
     },
     {
@@ -4756,6 +4949,19 @@
         "number": "R1-9",
         "topic": "Bengali",
         "author": "Bozhidar Bozhanov",
+        "category": [
+            "統語"
+        ],
+        "difficulty": {
+            "typical": 7,
+            "typicalStar": 7
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 7
+            }
+        ],
         "draft": false
     },
     {
@@ -4768,6 +4974,20 @@
         "number": "R2-1",
         "topic": "Quechua",
         "author": "Patrick Littell",
+        "category": [
+            "統語",
+            "文章"
+        ],
+        "difficulty": {
+            "typical": 2,
+            "typicalStar": 2
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 2
+            }
+        ],
         "draft": false
     },
     {
@@ -4780,6 +5000,20 @@
         "number": "R2-2",
         "topic": "Georgian, Armenian",
         "author": "Drago Radev",
+        "category": [
+            "文字",
+            "対応"
+        ],
+        "difficulty": {
+            "typical": 7,
+            "typicalStar": 7
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 7
+            }
+        ],
         "draft": false
     },
     {
@@ -4792,6 +5026,19 @@
         "number": "R2-3",
         "topic": "Beja",
         "author": "Dick Hudson",
+        "category": [
+            "統語"
+        ],
+        "difficulty": {
+            "typical": 7,
+            "typicalStar": 7
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 7
+            }
+        ],
         "draft": false
     },
     {
@@ -4804,6 +5051,19 @@
         "number": "R2-4",
         "topic": "Swedish",
         "author": "Patrick Littell",
+        "category": [
+            "未分類"
+        ],
+        "difficulty": {
+            "typical": 6,
+            "typicalStar": 6
+        },
+        "diffeach": [
+            {
+                "name": "karngati",
+                "diff": 6
+            }
+        ],
         "draft": false
     },
     {
@@ -6139,7 +6399,7 @@
         ],
         "translation": {
             "name": "fulfom",
-            "value": ">こんな文を言った人がいたとしよう：\n>\n>1. 花子はモリス的でスラシい\n>1. 春子はケンセンでブラス的だ\n>1. 夏海と航助はスラシいがダンジい\n>1. その先生はダンジくてクルブい\n>1. 千尋はブリシいがクルブい\n>1. 揚介はスロシカなだけでなくウイジくもある\n>1. 洋一はフラマジいのにスロシカだ\n>1. 昭子はツラギくてツラヒいので見ていると笑顔になれる\n>1. 太郎はウイジいのにツラギい\n>1. 冬子はブリシいがツラヒい\n>1. その営業さんたちはケンセンだったがスラシくはなかった\n>\n>問1. 次のうちどれがあり得る文か？\n>\n><div class=\"list-lower-latin\"></div>\n>\n>1. 雅美はブリシくてブラス的だ\n>1. その歌手はモリス的なだけでなくケンセンでもあった\n>1. 咲月はダンジいがスロシカな犬を見つけた\n>\n>問2. 人に求めたくなるような性質はどれか？(複数選択可)\r\n>\r\n><div class=\"list-lower-latin\"></div>\n>\n>1. ブリシい\n>1. ウイジい\n>1. スロシカだ\n>1. フラマジい\n>\n>:source:"
+            "value": ">こんな文を言った人がいたとしよう：\n>\n>1. 花子はモリス的でスラシい\n>1. 春子はケンセンでブラス的だ\n>1. 夏海と航助はスラシいがダンジい\n>1. その先生はダンジくてクルブい\n>1. 千尋はブリシいがクルブい\n>1. 揚介はスロシカなだけでなくウイジくもある\n>1. 洋一はフラマジいのにスロシカだ\n>1. 昭子はツラギくてツラヒいので見ていると笑顔になれる\n>1. 太郎はウイジいのにツラギい\n>1. 冬子はブリシいがツラヒい\n>1. その営業さんたちはケンセンだったがスラシくはなかった\n>\n>問1. 次のうちどれがあり得る文か？\n>\n><div class=\"list-lower-latin\"></div>\n>\n>1. 雅美はブリシくてブラス的だ\n>1. その歌手はモリス的なだけでなくケンセンでもあった\n>1. 咲月はダンジいがスロシカな犬を見つけた\n>\n>問2. 人に求めたくなるような性質はどれか？(複数選択可)\n>\n><div class=\"list-lower-latin\"></div>\n>\n>1. ブリシい\n>1. ウイジい\n>1. スロシカだ\n>1. フラマジい\n>\n>:source:"
         },
         "draft": false
     },

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -3,6 +3,11 @@
 <script src="https://cdn.jsdelivr.net/npm/js-base64@3.3.3/base64.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
 {{end}}
+{{if .Params.charts}}
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+{{ $databaseCharts := resources.Get "js/database-charts.js" }}
+<script src="{{ $databaseCharts.RelPermalink }}"></script>
+{{end}}
 <script src="https://unpkg.com/dexie@latest/dist/dexie.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,4 +1,4 @@
-{{if eq .RelPermalink "/problems/"}}
+{{if .Params.database}}
 <script src="https://unpkg.com/isotope-layout@3/dist/isotope.pkgd.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/js-base64@3.3.3/base64.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>

--- a/layouts/shortcodes/card-header.html
+++ b/layouts/shortcodes/card-header.html
@@ -1,0 +1,4 @@
+{{ $title := .Get "title" }}
+<div class="card">
+    {{with $title}}<div class="card-header"><h4 class="mb-0">{{.}}</h4></div>{{end}}{{.Inner | markdownify}}
+</div>

--- a/layouts/shortcodes/database-charts.html
+++ b/layouts/shortcodes/database-charts.html
@@ -1,0 +1,149 @@
+{{$problems := $.Site.Data.problems}}
+
+{{$contestCat := newScratch}}
+{{$contests := slice "JOL" "海外予選" "APLO" "IOL"}}
+{{range $contests}}
+    {{$cat := newScratch}}
+    {{range where $problems "venue" .}}
+        {{with index . "category"}}
+            {{range .}}
+                {{$cat.Add . 1}}
+            {{end}}
+        {{end}}
+    {{end}}
+    {{$contestCat.Set . $cat.Values}}
+{{end}}
+
+{{$categoryNames := slice}}
+{{$diffAll := newScratch}}
+{{$catAll := newScratch}}
+{{range $problems}}
+    {{with index . "difficulty"}}
+        {{$diffAll.Add (.typical | int | string) 1}}
+    {{else}}
+        {{$diffAll.Add "未定" 1}}
+    {{end}}
+    {{with index . "category"}}
+        {{range .}}
+            {{if eq . "ジャンル" | or (eq . "未分類")}}{{else}}
+                {{$name := strings.TrimPrefix "!" .}}
+                {{$categoryNames = $categoryNames | append $name}}
+                {{$catAll.Add $name 1}}
+            {{end}}
+        {{end}}
+    {{end}}
+{{end}}
+{{$categoryNames = $categoryNames | uniq}}
+{{$othercat := slice}}
+{{range $categoryNames}}
+{{if in $.Site.Params.probCategory.value .}}{{else}}
+    {{$othercat = $othercat | append .}}
+{{end}}
+{{end}}
+
+<div id="drawDifficultyOfEachContest"></div>
+<div id="drawCategoryOfEachContest"></div>
+<div id="drawCategory"></div>
+
+<script type="text/javascript">
+    function drawCharts() {
+        drawDifficultyOfEachContest();
+        drawCategoryOfEachContest();
+        drawCategory();
+    }
+
+    function drawDifficultyOfEachContest(){
+
+        var data = [
+            ['', '1', '2', '3', '4', '5', '6', '7', '8']
+        ];
+
+        {{$contests := slice "JOL" "海外予選" "APLO" "IOL"}}
+        {{range $k,$v := $contests}}
+            {{$diff := newScratch}}
+            {{range where $problems "venue" .}}
+                {{with index . "difficulty"}}
+                    {{$diff.Add (.typical | int | string) 1}}
+                {{else}}
+                    {{$diff.Add "未定" 1}}
+                {{end}}
+            {{end}}
+            {{$index := $k | add 1}}
+            {{$data := slice $v}}
+            {{$diffarray := slice}}
+            {{range (slice "1" "2" "3" "4" "5" "6" "7" "8")}}
+                {{$data = $data | append (($diff.Get .) | default 0)}}
+            {{end}}
+            data.push({{$data}});
+        {{end}}
+
+        var options_fullStacked = {
+            title: '大会ごとの難易度分布',
+            isStacked: 'percent',
+            height: 300,
+            legend: {position: 'top', maxLines: 3},
+            colors: ['#BCAAA4', '#9CCC65', '#26C6DA', '#1E88E5', '#FDD835', '#FF9800', '#F44336', '#8E24AA'],
+            hAxis: {
+                minValue: 0,
+                ticks: [0, .3, .6, .9, 1]
+            }
+        };
+        var visualization = new google.visualization.BarChart(document.getElementById('drawDifficultyOfEachContest'));
+        visualization.draw(google.visualization.arrayToDataTable(data), options_fullStacked);
+    }
+
+    function drawCategoryOfEachContest() {
+        {{$categories := $.Site.Params.probCategory.value}}
+        var colh = ["cat"].concat({{$categories}});
+        var data = [colh];
+        {{range $k,$v := $contests}}
+            {{$data := slice $v}}
+            {{range $categories}}
+                {{$data = $data | append ((index ($contestCat.Get $v) .) | int)}}
+            {{end}}
+            data.push({{$data}});
+        {{end}}
+
+        var options = {
+            title: '大会ごとの主要ジャンル出題割合',
+            isStacked: 'percent',
+            height: 300,
+            legend: { position: 'top', maxLines: 3 },
+            hAxis: {
+                minValue: 0,
+                ticks: [0, .3, .6, .9, 1]
+            }
+        };
+
+        var chart = new google.visualization.BarChart(document.getElementById('drawCategoryOfEachContest'));
+        chart.draw(google.visualization.arrayToDataTable(data), options);
+    }
+
+    function drawCategory(){
+        var colh = [['cat','freq']];
+        var data = [];
+            {{range $categoryNames}}
+                {{$data := slice . (($catAll.Get .) | int)}}
+                data.push({{$data}});
+            {{end}}
+        data.sort((a,b)=>{
+            return b[1] - a[1];
+        })
+        var data = colh.concat(data);
+        var options = {
+            title: 'ジャンル出題回数ランキング',
+            height: data.length * 20 + 80,
+            chartArea:{
+                left:'100',
+                height: data.length * 20
+            },
+            legend: { position: 'none', maxLines: 3 },
+            hAxis: {
+                minValue: 0
+            }
+        };
+        var chart = new google.visualization.BarChart(document.getElementById('drawCategory'));
+        chart.draw(google.visualization.arrayToDataTable(data), options);
+    }
+
+</script>

--- a/layouts/shortcodes/database-contests.html
+++ b/layouts/shortcodes/database-contests.html
@@ -1,0 +1,374 @@
+{{$arrrayProbdata := where $.Site.Data.problems "draft" false}}
+{{$contestdata := $.Site.Data.contests}}
+
+{{$prob := newScratch}}
+{{range $k, $v := $arrrayProbdata}}
+    {{ $tmpVenue := "" }}
+    {{ if isset $v "venue" }}
+        {{ $tmpVenue = $v.venue }}
+        {{with $v.venuedetail }}
+            {{ $tmpVenue = . }}
+        {{end}}
+        {{ $prob.Add "venue" (slice $tmpVenue )}}
+        {{if isset $v "year" }}
+            {{ $prob.Add $tmpVenue (slice $v.year )}}
+            {{ $prob.Add (string (delimit (slice $tmpVenue (string $v.year)) "")) (slice $k) }}
+        {{end}}
+    {{end}}
+{{end}}
+{{$prob.Set "venue" (uniq ($prob.Get "venue")) }}
+{{range ($prob.Get "venue")}}
+    {{$prob.Set . (uniq ($prob.Get .)) }}
+{{end}}
+
+<div class="position-relative">
+<div id="search-console">
+<div id="private-title" class="align-items-center">
+    <p class="mr-auto d-inline-flex mb-0">
+        <i class="fas fa-share align-self-center mr-2"></i>
+        <span id="private-title-text"></span>
+    </p>
+        <div id="private-filter-btngroup">
+            <input type="checkbox" hidden id="private-filter-off-input">
+            <label class="btn btnfn mb-2" id="private-filter-off" for="private-filter-off-input">
+                <i class="fas fa-filter fa-fw"></i>これだけ
+            </label>
+            <button class="btn btnfn btnfn-danger" id="private-filter-clear">
+                <i class="fas fa-trash fa-fw"></i>CLEAR
+            </button>
+        </div>
+</div>
+<div id="allfilter">
+<p><input type="text" class="quicksearch form-control" id="quicksearch" placeholder="検索" /></p>
+
+<div id="filter">
+{{$filterVenue := ($prob.Get "venue")}}
+<div class="filter-group" id="filter-venue" data-filter-group="venue">
+    <span>
+        出題元
+    </span>
+    {{ with $filterVenue }}
+    <div class="unmot">
+        {{range .}}
+            <input class="filter-input" type="checkbox" checked hidden id="{{.}}" data-filter=":not(.{{.}})" autocomplete="off">
+            <label class="{{.}}" for="{{.}}">{{.}}</label>
+        {{end}}
+    </div>
+    {{end}}
+</div>
+</div>
+
+</div>
+
+<div>
+    <span>ソート</span>
+    <div class="btn-group btn-group-toggle sort-by-button-group" id="sort-by-button-group" data-toggle="buttons">
+        <label for="venue-year" class="btn sort isSortAscending" data-sort-by="year">
+            <input hidden type="radio" name="sort" id="venue-year" autocomplete="off">年<i class="fas fa-sort-up"></i><i class="fas fa-sort-down"></i>
+        </label>
+    </div>
+    <button class="btn btnfn btn-primary rounded-circle" id="shuffle"><i class="fas fa-random"></i></button>
+</div>
+
+<div class="d-flex mt-2">
+    <p class="text-muted mb-0 align-self-center mr-auto" id="output">——</p>
+    <div>
+        <button class="btn btnfn btnfn-danger" id="clear"><i class="fas fa-trash fa-fw"></i>CLEAR</button>
+    </div>
+</div>
+
+</div>
+</div>
+
+<div id="filter-container" class="mt-4 row">
+
+{{range ($prob.Get "venue" )}}
+{{$tmpVenue := .}}
+{{range ($prob.Get .)}}
+{{$contest := index (where (where $contestdata "venue" $tmpVenue) "year" .) 0}}
+{{$key := string (delimit (slice $tmpVenue (string .)) "")}}
+{{$detailpath := slice "/problems"}}
+{{with $contest.venuecompatiable}}{{$detailpath = $detailpath | append (. | urlize)}}{{end}}
+{{$detailpath = $detailpath | append ($contest.venue | urlize)}}
+{{$namedyear := cond (lt . 0) (index $.Site.Params.namedyear .) .}}
+{{$detailpath = $detailpath | append ($namedyear | urlize)}}
+{{$probcorrection := slice}}
+{{$solcorrection := false}}
+{{range ($prob.Get $key)}}
+    {{$problem := index $arrrayProbdata .}}
+    {{with $problem.probcorrection}}
+        {{$probcorrection = $probcorrection | append (slice (delimit (slice $problem.number $problem.probcorrection) ": "))}}
+    {{end}}
+    {{with $problem.solcorrection}}
+        {{$solcorrection = true}}
+    {{end}}
+{{end}}
+<div id="{{$key}}" data-id="{{$key}}" class="filter-item {{$tmpVenue}} col-12">
+    <div class="card">
+        <div class="card-header">{{$problinktext := "問題"}}{{$sollinktext := "解答"}}{{if eq $tmpVenue "IOL"}}{{$problinktext = "個人戦問題"}}{{$sollinktext = "個人戦解答"}}{{end}}
+            <div class="d-flex">
+                <h5 class="mr-auto"><a class="text-dark" href="{{path.Join $detailpath}}"><span class="sort-venue">{{$tmpVenue}}</span><span class="sort-year sr-only">{{.}}</span>{{$namedyear}}</a></h5>
+                {{with $probcorrection}}<h5 class="text-muted"><a class="text-muted" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" title="問題訂正" data-content="{{delimit . "\n"}}"><i class="fas fa-exclamation-circle fa-fw"></i></a></h5>{{end}}
+                {{with $solcorrection}}<h5 class="text-muted"><a class="text-muted" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" title="解答訂正" data-content="解答の訂正あり"><i class="fas fa-exclamation-circle fa-fw"></i></a></h5>{{end}}
+            </div>
+            <a href="{{$contest.prob}}" class="card-link unmot ml-1_25" target="_blank">{{$problinktext}}</a>
+            {{if eq $tmpVenue "IOL"}}{{$teamdetailpath := (slice "/problems" "iol" (string .)) | append ("team-1" | urlize)}}
+            <a href="{{$contest.teamprob | default (path.Join $teamdetailpath) }}" class="card-link unmot" target="_blank">団体戦</a>{{end}}
+            {{with $contest.probsol}}<a href="{{.}}" class="card-link unmot" target="_blank">{{$sollinktext}}</a>{{end}}
+            {{with $contest.teamsol}}<a href="{{.}}" class="card-link unmot" target="_blank">団体戦解答</a>{{end}}
+            <a class="card-link unmot" data-toggle="collapse" href data-target="#collapse{{$key}}" role="button" aria-expanded="false" aria-controls="collapse{{$key}}"><i class="fas fa-angle-right fa-fw"></i>出題問題一覧</a>
+        </div>
+        <div class="card-body collapse itmclps transition-none" id="collapse{{$key}}">
+            <div class="card-title">出題問題一覧</div>
+            <table class="table">
+                <tbody>
+                {{range ($prob.Get $key)}}
+                {{$yearteamnum := $detailpath}}
+                {{$problem := index $arrrayProbdata .}}
+                {{$teamnum := slice "" }}
+                {{if isset $problem "team"}}{{$teamnum = slice "team" $problem.number}}
+                {{else}}{{$teamnum = slice $problem.number}}
+                {{end}}
+                {{$yearteamnum = $yearteamnum | append ((delimit $teamnum "-") | urlize)}}
+                <tr>
+                    <th class="d-inline-block d-sm-table-cell p-1">{{$problem.team}}{{$problem.number}}</th>
+                    <td class="d-inline-block d-sm-table-cell p-1"><a href="{{path.Join $yearteamnum}}">{{$problem.titlejp | default $problem.title}}</a></td>
+                    <td class="d-block d-lg-table-cell p-1"><p class="m-auto text-muted"><a class="text-muted" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" title="難易度の評定" data-content="{{range index $problem "diffeach"}}{{.diff}} by {{.name}}; {{end}}">{{index (index $.Site.Params.diffstar "value") ((index $problem "difficulty").typicalStar|int) |safeHTML}}{{with (index $problem "difficulty").typical}}{{.}}{{end}}</a></p></td>
+                    <td class="d-block d-lg-table-cell p-1"><p class="mb-0 text-muted">{{range $problem.category}}{{if hasPrefix . "!"}}{{else}}<span class="tag m-1 unmot">{{.}}</span> {{end}}{{else}}<span class="tag m-1 unmot">未分類</span>{{end}}</p></td>
+                </tr>
+                {{end}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{{end}}
+{{end}}
+
+</div>
+
+<script language="JavaScript" type="text/javascript">
+    $(function() {
+        
+        var filterValue = '*';
+        var qsRegex;
+        var $filterOff = $('#private-filter-off-input');
+        var $allfilter = $('#allfilter');
+        var $qs = $('#quicksearch');
+        var $filterInputs = $('.filter-input');
+        var $checkboxes = $('#filter input[type="checkbox"]');
+        var $venueCheckboxes = $('#filter-venue input[type="checkbox"]');
+        
+        var $iso = $('#filter-container').isotope({
+            // options
+            itemSelector: '.filter-item',
+            layoutMode: 'fitRows',
+            fitRows: {
+                gutter: 10 
+            },
+            filter: function() {
+                var $this = $(this);
+                var searchResult = qsRegex ? $this.text().match( qsRegex ) : true;
+                var filterResult = filterValue ? $this.is( filterValue ) : true;
+                return searchResult && filterResult;
+            },
+            getSortData: {
+                venue: '.sort-venue',
+                year: '.sort-year parseInt'
+            },
+        });
+        var iso = $iso.data('isotope');
+
+        //sort
+        $('#sort-by-button-group').on( 'click', 'label', function() {
+            var $this = $(this);
+            var sortByValue = $this.attr('data-sort-by');
+            if (sortByValue !== 'original-order' && sortByValue.match(/-/g)) sortByValue = sortByValue.split('-');
+            var isSortAscending = $this.hasClass('isSortAscending');
+            if($this.hasClass('active')){
+                isSortAscending = !isSortAscending;
+                $this.toggleClass('isSortAscending');
+            }
+            $iso.isotope({ sortBy: sortByValue, sortAscending: isSortAscending });
+        });
+        $('#shuffle').on( 'click', function() {
+            $('#sort-by-button-group label').removeClass('active');
+            $('#sort-by-button-group input').removeProp('checked');
+            $iso.isotope('shuffle');
+        });
+
+        //テキスト検索
+        $qs.keyup( debounce( function() {
+            qsRegex = new RegExp( $qs.val(), 'gi' );
+            $iso.isotope();
+            countHit();
+        }) );
+
+        function debounce( fn, threshold ) {
+            var timeout;
+            threshold = threshold || 100;
+            return function debounced() {
+                clearTimeout( timeout );
+                var args = arguments;
+                var _this = this;
+                function delayed() {
+                fn.apply( _this, args );
+                }
+                timeout = setTimeout( delayed, threshold );
+            };
+        }
+
+        //フィルター(カテゴリーと便利以外)
+        function updateCheck(){
+
+            //フィルター処理
+            var filters = [];
+            $checkboxes.each(function(i, elem){
+                if(false == elem.checked){
+                    filters.push(elem.getAttribute('data-filter'));
+                }
+            });
+            filterValue = filters.length ? filters.join('') : '*';
+        }
+
+        $checkboxes.change(function(){
+            var $this = $(this);
+
+            //反転
+            if(false == $this.prop('checked')){
+                reverse($this);
+            }
+
+            updateCheck();
+            endUpdate();
+        });
+
+        //これ以降共通機能
+
+        //反転
+        function reverse($this){
+            var $checked = $this.siblings('input[type="checkbox"]:checked:not([style="display: none;"])');
+            var $siblings = $this.siblings('input[type="checkbox"]:not([style="display: none;"])');
+            if(0 == $siblings.length - $checked.length){
+                $siblings.prop('checked', false);
+                $this.prop('checked', true);
+            }
+            else if(0 == $checked.length){
+                $siblings.prop('checked', true);
+                $this.prop('checked', true);
+            }
+            return;
+        };
+
+        //ヒット数
+        function countHit(){
+            var text = iso.filteredItems.length;
+            $('#output').text( '—— ' + text + '問');
+        }
+
+        function endUpdate(option = {}, delay = 250){
+            return new Promise(resolve => 
+                setTimeout(function(){
+                    $iso.isotope(option);
+                    countHit();
+                    resolve();
+                },delay)
+            );
+        }
+
+        //クリアボタン押下時
+        //フィルター類をデフォルトに戻す
+        $('#clear').on('click', function(){
+            $filterInputs.each(function(){
+                if($(this).hasClass('default-notchecked')){
+                    $(this).prop('checked',false);
+                }
+                else{
+                    $(this).prop('checked',true);
+                }
+            });
+            $('#sort-by-button-group label').removeClass('active').addClass('isSortAscending');
+            $('#sort-by-button-group input').removeProp('checked');
+            updateFilters();
+            $qs.val('');
+            qsRegex = '';
+            endUpdate({ sortBy : 'original-order', sortAscending: true });
+        });
+
+        async function genURL(){
+            var genurl = location.origin + '/problems/contests/';
+            return genurl;
+        }
+
+        function content(genurl){
+            return '<div id="popover-link"><a href="' + genurl + '">' + genurl + '</a>' + '</div>';
+        }
+        function title(genurl){
+            return '<div class="d-flex"><span class="mr-auto align-self-center"><i class="fas fa-search fa-fw"></i>検索結果をシェア！</span>' + '<button id="clipbtn" class="btn btn-primary btnfn rounded-circle" data-clipboard-text="' + genurl + '"><i class="fas fa-clipboard"></i></button></div>';
+        }
+
+        //shareボタン押下時
+        $('#share').on('click', async function(){
+            var $this = $(this);
+            var genurl = '';
+            await genURL().then(v =>{
+                genurl = v;
+            });
+            $this.popover('dispose');
+            $this.popover({
+                title: title(genurl),
+                content: content(genurl),
+                html: true,
+                placement: 'top',
+                trigger: 'click'
+            });
+            $this.popover('show');
+            $('#clipbtn').tooltip({
+                title: 'Copy',
+                trigger: 'hover'
+            });
+        });
+
+        $(document).on('keyup', '#private-title-form', debounce( async function() {
+            //キーが打たれる度に，urlを生成しなおして，popover の html のリンク部分を直接変える．
+            privateTitle = $('#private-title-form').val();
+            var genurl = '';
+            await genURL().then(v =>{
+                genurl = v;
+            });
+            $('#' + $('#share').attr('aria-describedby')).find('#popover-link').html(content(genurl));
+            $('#' + $('#share').attr('aria-describedby')).find('.popover-header').html(title(genurl));
+            $('#clipbtn').tooltip({
+                title: 'Copy',
+                trigger: 'hover'
+            });
+        }));
+
+        $('body').on('click', function (e) {
+            $('#share').each(function () {
+                //the 'is' for buttons that trigger popups
+                //the 'has' for icons within a button that triggers a popup
+                if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+                    $(this).popover('hide');
+                }
+            });
+        });
+    
+        var clipboard = new ClipboardJS('#clipbtn');
+        clipboard.on('success', function(e) {
+            $('#clipbtn').tooltip('dispose').tooltip({title: 'Copied!'}).tooltip('show');
+        });
+
+        //全フィルターのアップデート
+        function updateFilters(){
+            updateCheck();
+        }
+
+        $('.itmclps').on('shown.bs.collapse', function(){
+            endUpdate({},0);
+        });
+        $('.itmclps').on('hidden.bs.collapse', function(){
+            endUpdate({},0);
+        });
+    });
+</script>

--- a/layouts/shortcodes/database.html
+++ b/layouts/shortcodes/database.html
@@ -234,7 +234,7 @@
                 var categoryFilterResult = categoryFilterValue ? $this.is( categoryFilterValue ) : true;
                 var utilityFilterResult = utilityFilterValue ? $this.is( utilityFilterValue ) : true;
                 var privateFilterResult = isprivate ? privateFilter[this.getAttribute('data-id')-1] : true;
-                return $filterOff.prop('checked') ? privateFilterResult : privateFilterResult && searchResult && filterResult && categoryFilterResult && utilityFilterResult;
+                return isprivate && $filterOff.prop('checked') ? privateFilterResult : privateFilterResult && searchResult && filterResult && categoryFilterResult && utilityFilterResult;
             },
             getSortData: {
                 venue: '.sort-venue',
@@ -569,14 +569,14 @@
             var private = veqp();
             var boollist = [];
             
+            if(privateTitle){
+                query.s = Base64.encodeURI(privateTitle);
+            }
             if(private || isprivate ){
                 query.v = 'p';
                 iso.filteredItems.map((v) => {
                     boollist[v.sortData.probid-1] = true;
                 });
-                if(privateTitle){
-                    query.s = Base64.encodeURI(privateTitle);
-                }
             }
             else{
                 query.v = 1;
@@ -711,7 +711,33 @@
                     result[index] = param.bulkPut(data[index]);
                 });
                 await Promise.all(result);
-                location.search = '';
+                var title = getParam('s');
+                if(title){
+                    await Promise.all([
+                        //indexedDBからデータ取得してprop反映
+                        db.checked.toCollection().primaryKeys(function(keysArray){
+                            DBtoFilters(keysArray, true);
+                        }),
+                        db.notchecked.toCollection().primaryKeys(function(keysArray){
+                            DBtoFilters(keysArray, false);
+                        }),
+                        db.text.get('quicksearch',function(v){
+                            if(v){
+                                $qs.val(v.text);
+                                qsRegex = v.text;
+                            }
+                        })
+                    ]);
+                    updateFilters();
+                    await endUpdate();
+                    isprivate = true;
+                    var genurl = '';
+                    await genURL().then(v =>{
+                        genurl = v;
+                    });
+                    location = genurl + '&s=' + title;
+                }
+                else location.search = '';
             }
             return true;
         }

--- a/layouts/shortcodes/list.html
+++ b/layouts/shortcodes/list.html
@@ -1,0 +1,21 @@
+{{ $attrs := "" }}
+{{ $liattrs := "" }}
+{{ $aattrs := "" }}
+{{ range $k, $v := .Params }}
+  {{if hasPrefix $k "li"}}
+    {{ $liattrs = printf "%s %s=\"%v\"" $liattrs (strings.TrimPrefix "li" $k) $v }}
+  {{else}}
+    {{if hasPrefix $k "a"}}
+      {{ $aattrs = printf "%s %s=\"%v\"" $aattrs (strings.TrimPrefix "a" $k) $v }}
+    {{else}}
+      {{ $attrs = printf "%s %s=\"%v\"" $attrs $k $v }}
+    {{end}}
+  {{end}}
+{{ end }}
+
+{{ $newUl := printf "<ul %s>" $attrs }}
+{{ $newOl := printf "<ol %s>" $attrs }}
+{{ $newli := printf "<li %s>" $liattrs }}
+{{ $newa := printf "<a %s" $aattrs }}
+{{ $inner := (.Inner | markdownify) }}
+{{ (replace (replace (replace (replace $inner "<a" $newa) "<li>" $newli) "<ol>" $newOl) "<ul>" $newUl) | safeHTML }}

--- a/layouts/shortcodes/problems/introduction.html
+++ b/layouts/shortcodes/problems/introduction.html
@@ -1,0 +1,6 @@
+{{$id := .Get "id"}}
+{{$arrayProbData := where $.Site.Data.problems "id" $id}}
+{{$prob := index $arrayProbData 0}}
+{{$introduction := $prob.introduction }}
+
+<div class="p-2">{{ $introduction | markdownify }}</div>

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,0 +1,7 @@
+{{ $attrs := "" }}
+{{ range $k, $v := .Params }}
+  {{ $attrs = printf "%s %s=\"%v\"" $attrs $k $v }}
+{{ end }}
+
+{{ $newTable := printf "<table %s>" $attrs }}
+{{ (replace (.Inner | markdownify) "<table>" $newTable) | safeHTML }}

--- a/layouts/shortcodes/wrap.html
+++ b/layouts/shortcodes/wrap.html
@@ -1,0 +1,3 @@
+{{(delimit (slice "<" (.Get "tag") " class=" (.Get "class") ">") "") | safeHTML}}
+{{.Inner | markdownify}}
+{{(delimit (slice "</" (.Get "tag") ">") "") | safeHTML}}


### PR DESCRIPTION
- 問題ごとに分かれてるより年ごとに分かれてた方が便利なときもあると思ったので，年ごとになってるページを追加
- 統計ページを追加
- 問題をシェアするとき，タイトルを付けられる機能を少しだけ拡張
- 詳細ページの一番上に紹介文を載せるスペースを追加
- スプレッドシートのデータを反映